### PR TITLE
feature round-up without borking your fly.io config

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,12 @@ A Discord bot for **Dune: Awakening** guilds to convert spice sand to melange, m
   - **Guild Cut:** Percentage taken off the top (default: 10%)
   - **User Percentages:** Users with percentages get exact amounts, others split equally
   - **Creates:** Expedition records and tracks melange owed for payout
-
+- **`/fixedratecut <total_sand> <users> [optional: rate]`** - Alternative split - Give each user a fixed % payout of spice and the leftover goes to guild
+  - **Example:** `/split 10000 "@harvester @scout @pilot" 15`
+  - **Guild Cut:** All leftover sand goes to guild
+  - **User Percentages:** Equal percent cuts for each user (default: 5%)
+  - **Creates:** Expedition records and tracks melange owed for payout
+  
 ### 🏛️ Guild Admin Commands
 - **`/pending`** - View all users with pending melange payments and amounts owed
 - **`/payment <user>`** - Process payment for a specific harvester's deposits
@@ -194,4 +199,5 @@ python -m pytest tests/ --cov=. --cov-report=html
 **🎮 Game:** Dune: Awakening  
 **🚀 Status:** Production Ready  
 **📊 Deployment:** Fly.io + Supabase  
+
 **🧪 Tests:** 46 passing ✅

--- a/bot.py
+++ b/bot.py
@@ -163,7 +163,7 @@ def register_commands():
         rate="The percentage rate for each user (default: 5)",
         landsraad_bonus="Whether or not Landsraad crafting bonus is in effect (default:false)"    
     )
-    async def fixedratecut_cmd(interaction: discord.Interaction, total_sand: int, users: str, rate: int = 5, landsraad_bonus: bool = False)  # noqa: F841
+    async def fixedratecut_cmd(interaction: discord.Interaction, total_sand: int, users: str, rate: int = 5, landsraad_bonus: bool = False):  # noqa: F841
         await fixedratecut(interaction, total_sand, users, rate, landsraad_bonus, True)
 
     # Help command

--- a/bot.py
+++ b/bot.py
@@ -49,9 +49,9 @@ async def on_ready():
         else:
             logger.bot_event("Bot started - Unknown")
             logger.info("Bot is online")
-        
+
         logger.info("Starting bot initialization")
-        
+
         # Test database connectivity
         try:
             logger.info("Testing database connection")
@@ -59,31 +59,31 @@ async def on_ready():
             await get_database().initialize()
             db_init_time = time.time() - db_init_start
             logger.bot_event("Database connection verified", db_init_time=f"{db_init_time:.3f}s")
-                
+
         except Exception as error:
             db_init_time = time.time() - db_init_start
             logger.bot_event(f"Database connection failed: {error}", db_init_time=f"{db_init_time:.3f}s")
             logger.error(f"Database connection failed in {db_init_time:.3f}s", error=str(error), error_type=type(error).__name__)
             logger.debug("Database connection failure traceback", traceback=traceback.format_exc())
             return
-        
+
         # Register commands BEFORE syncing
         logger.info("Registering commands")
         register_start = time.time()
         register_commands()
         register_time = time.time() - register_start
         logger.info("Command registration completed", register_time=f"{register_time:.3f}s")
-        
+
         # Auto-sync commands on startup (can be disabled with AUTO_SYNC_COMMANDS=false)
         auto_sync = os.getenv('AUTO_SYNC_COMMANDS', 'true').lower() == 'true'
         if auto_sync:
             try:
                 logger.info("Auto-syncing commands (global + guild)")
-                
+
                 # Global sync first to update all guilds
                 global_synced = await bot.tree.sync()
                 logger.info("Global sync completed", commands_synced=len(global_synced))
-                
+
                 # Guild-specific sync for immediate effect in current guilds
                 guild_sync_count = 0
                 for guild in bot.guilds:
@@ -93,23 +93,23 @@ async def on_ready():
                         logger.info("Guild sync completed", guild_name=guild.name, commands_synced=len(guild_synced))
                     except Exception as guild_error:
                         logger.warning("Guild sync failed", guild_name=guild.name, error=str(guild_error))
-                
+
                 logger.info("Auto-sync completed", global_commands=len(global_synced), guild_commands=guild_sync_count)
-                
+
             except Exception as sync_error:
                 logger.error("Auto-sync failed", error=str(sync_error))
                 logger.debug("Auto-sync failure traceback", traceback=traceback.format_exc())
-        
+
         logger.info("Bot is ready! Use /sync command to sync slash commands")
-        
+
         # Log total bot startup time
         total_startup_time = time.time() - bot_start_time
-        logger.bot_event(f"Bot startup completed", 
+        logger.bot_event(f"Bot startup completed",
                          total_startup_time=f"{total_startup_time:.3f}s",
                          db_init_time=f"{db_init_time:.3f}s",
                          guild_count=len(bot.guilds))
         logger.info("Bot startup completed", total_startup_time=f"{total_startup_time:.3f}s")
-            
+
     except Exception as error:
         total_startup_time = time.time() - bot_start_time
         logger.error("CRITICAL ERROR in on_ready", error=str(error), error_type=type(error).__name__, startup_time=f"{total_startup_time:.3f}s")
@@ -120,27 +120,27 @@ async def on_ready():
 # Register commands with the bot's command tree
 def register_commands():
     """Register all commands explicitly with their exact signatures"""
-    from commands import sand, refinery, leaderboard, split, help, reset, ledger, expedition, payment, payroll, treasury, guild_withdraw, pending
-    
+    from commands import sand, refinery, leaderboard, split, help, reset, ledger, expedition, payment, payroll, treasury, guild_withdraw, pending, fixedratecut
+
     # Sand command (formerly harvest)
     @bot.tree.command(name="sand", description="Convert spice sand into melange (50:1 ratio)")
     @app_commands.describe(amount="Amount of spice sand to convert (1-10,000)")
     async def sand_cmd(interaction: discord.Interaction, amount: int):  # noqa: F841
         await sand(interaction, amount, True)
-    
+
     # Refinery command
     @bot.tree.command(name="refinery", description="View your melange production and payment status")
     async def refinery_cmd(interaction: discord.Interaction):  # noqa: F841
         await refinery(interaction, True)
-    
+
     # Leaderboard command
     @bot.tree.command(name="leaderboard", description="Display top spice refiners by melange production")
     @app_commands.describe(limit="Number of top refiners to display (5-25, default: 10)")
     async def leaderboard_cmd(interaction: discord.Interaction, limit: int = 10):  # noqa: F841
         await leaderboard(interaction, limit, True)
-    
 
-    
+
+
     # Split command
     @bot.tree.command(name="split", description="Split spice sand among expedition members and convert to melange")
     @app_commands.describe(
@@ -150,29 +150,39 @@ def register_commands():
     )
     async def split_cmd(interaction: discord.Interaction, total_sand: int, users: str, guild: int = 10):  # noqa: F841
         await split(interaction, total_sand, users, guild, True)
-    
+
+    # Fixed Rate Cut command
+    @bot.tree.command(name="fixedratecut", description="Awards a fixed percentage of spice sand to tagged users")
+    @app_commands.describe(
+        total_sand="Total spice sand to distribute",
+        users="Users to award a cut to",
+        rate="The percentage rate for each user (default: 5)"
+    )
+    async def fixedratecut_cmd(interaction: discord.Interaction, total_sand: int, users: str, rate: int = 5):  # noqa: F841
+        await fixedratecut(interaction, total_sand, users, rate, True)
+
     # Help command
     @bot.tree.command(name="help", description="Show all available spice tracking commands")
     async def help_cmd(interaction: discord.Interaction):  # noqa: F841
         await help(interaction, True)
-    
+
     # Reset command
     @bot.tree.command(name="reset", description="Reset all spice refinery statistics (Admin only - USE WITH CAUTION)")
     @app_commands.describe(confirm="Confirm that you want to delete all refinery data (True/False)")
     async def reset_cmd(interaction: discord.Interaction, confirm: bool):  # noqa: F841
         await reset(interaction, confirm, True)
-    
+
     # Ledger command
     @bot.tree.command(name="ledger", description="View your complete spice harvest ledger")
     async def ledger_cmd(interaction: discord.Interaction):  # noqa: F841
         await ledger(interaction, True)
-    
+
     # Expedition command
     @bot.tree.command(name="expedition", description="View details of a specific expedition")
     @app_commands.describe(expedition_id="ID of the expedition to view")
     async def expedition_cmd(interaction: discord.Interaction, expedition_id: int):  # noqa: F841
         await expedition(interaction, expedition_id, True)
-    
+
     # Pay command (formerly payment)
     @bot.tree.command(name="pay", description="Process melange payment for a user (Admin only)")
     @app_commands.describe(
@@ -181,17 +191,17 @@ def register_commands():
     )
     async def pay_cmd(interaction: discord.Interaction, user: discord.Member, amount: int = None):  # noqa: F841
         await payment(interaction, user, amount, True)
-    
+
     # Payroll command
     @bot.tree.command(name="payroll", description="Process payments for all unpaid harvesters (Admin only)")
     async def payroll_cmd(interaction: discord.Interaction):  # noqa: F841
         await payroll(interaction, True)
-    
+
     # Treasury command
     @bot.tree.command(name="treasury", description="View guild treasury balance and statistics")
     async def treasury_cmd(interaction: discord.Interaction):  # noqa: F841
         await treasury(interaction, True)
-    
+
     # Guild Withdraw command
     @bot.tree.command(name="guild_withdraw", description="Withdraw sand from guild treasury to give to a user (Admin only)")
     @app_commands.describe(
@@ -200,26 +210,26 @@ def register_commands():
     )
     async def guild_withdraw_cmd(interaction: discord.Interaction, user: discord.Member, amount: int):  # noqa: F841
         await guild_withdraw(interaction, user, amount, True)
-    
+
     # Pending command
     @bot.tree.command(name="pending", description="View all users with pending melange payments (Admin only)")
     async def pending_cmd(interaction: discord.Interaction):  # noqa: F841
         await pending(interaction, True)
-    
+
     # Sync command (slash command version)
     @bot.tree.command(name="sync", description="Sync slash commands (Bot Owner Only)")
     async def sync_cmd(interaction: discord.Interaction):  # noqa: F841
         if interaction.user.id != int(os.getenv('BOT_OWNER_ID', '0')):
             await interaction.response.send_message("❌ Only the bot owner can use this command.", ephemeral=True)
             return
-        
+
         try:
             await interaction.response.defer(ephemeral=True)
             synced = await bot.tree.sync()
             await interaction.followup.send(f"✅ Synced {len(synced)} commands successfully!", ephemeral=True)
         except Exception as e:
             await interaction.followup.send(f"❌ Error syncing commands: {e}", ephemeral=True)
-    
+
     logger.info("Registered all commands explicitly")
 
 
@@ -269,7 +279,7 @@ bot.add_command(sync)
 @bot.event
 async def on_command_error(ctx, error):
     error_start = time.time()
-    logger.error("Command error", event_type="command_error", 
+    logger.error("Command error", event_type="command_error",
                  command=ctx.command.name if ctx.command else "unknown",
                  user_id=str(ctx.author.id) if ctx.author else "unknown",
                  username=ctx.author.display_name if ctx.author else "unknown",
@@ -288,14 +298,14 @@ def start_health_server():
     class HealthHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
             request_start = time.time()
-            
+
             if self.path == '/health':
                 self.send_response(200)
                 self.send_header('Content-type', 'text/plain')
                 self.send_header('Cache-Control', 'no-cache, no-store, must-revalidate')
                 self.send_header('Connection', 'keep-alive')
                 self.end_headers()
-                
+
                 # Return bot status information
                 status = {
                     'status': 'healthy',
@@ -304,34 +314,34 @@ def start_health_server():
                     'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
                 }
                 self.wfile.write(str(status).encode())
-                
+
                 request_time = time.time() - request_start
-                logger.info(f"Health check request completed", 
+                logger.info(f"Health check request completed",
                            request_time=f"{request_time:.3f}s",
                            bot_ready=bot.is_ready(),
                            guild_count=len(bot.guilds))
-                
+
             elif self.path == '/ping':
                 self.send_response(200)
                 self.send_header('Content-type', 'text/plain')
                 self.end_headers()
                 self.wfile.write(b'pong')
-                
+
                 request_time = time.time() - request_start
                 logger.info(f"Ping request completed", request_time=f"{request_time:.3f}s")
-                
+
             else:
                 self.send_response(404)
                 self.end_headers()
-                
+
                 request_time = time.time() - request_start
-                logger.warning(f"Invalid health check request", 
-                               path=self.path, 
+                logger.warning(f"Invalid health check request",
+                               path=self.path,
                                request_time=f"{request_time:.3f}s")
-        
+
         def log_message(self, format, *args):
             pass  # Suppress HTTP server logs
-    
+
     try:
         port = int(os.getenv('PORT', 8080))
         with socketserver.TCPServer(("", port), HealthHandler) as httpd:
@@ -347,7 +357,7 @@ if __name__ == '__main__':
     # Start health check server in a separate thread for Fly.io
     health_thread = threading.Thread(target=start_health_server, daemon=True)
     health_thread.start()
-    
+
     # Start a keep-alive thread to prevent machine from going idle
     def keep_alive():
         """Send periodic pings to keep the machine alive"""
@@ -359,37 +369,37 @@ if __name__ == '__main__':
                 response = requests.get('http://localhost:8080/ping', timeout=5)
                 ping_time = time.time() - ping_start
                 ping_count += 1
-                
-                logger.info(f"Keep-alive ping completed", 
+
+                logger.info(f"Keep-alive ping completed",
                            ping_count=ping_count,
                            ping_time=f"{ping_time:.3f}s",
                            status_code=response.status_code)
-                
+
             except Exception as e:
                 ping_count += 1
-                logger.warning(f"Keep-alive ping failed", 
+                logger.warning(f"Keep-alive ping failed",
                                ping_count=ping_count,
                                error=str(e))
                 pass  # Ignore errors, just keep trying
-    
+
     keep_alive_thread = threading.Thread(target=keep_alive, daemon=True)
     keep_alive_thread.start()
-    
+
     token = os.getenv('DISCORD_TOKEN')
     if not token:
         logger.error("DISCORD_TOKEN environment variable is not set")
         logger.error("Please set the DISCORD_TOKEN environment variable in Fly.io or your .env file")
         exit(1)
-    
+
     startup_start = time.time()
     logger.bot_event(f"Bot starting - Token present: {bool(token)}")
     logger.info("Starting Discord bot")
-    
+
     try:
         bot.run(token)
     except Exception as e:
         startup_time = time.time() - startup_start
-        logger.error(f"Bot startup failed", 
+        logger.error(f"Bot startup failed",
                      startup_time=f"{startup_time:.3f}s",
                      error=str(e))
         raise e

--- a/bot.py
+++ b/bot.py
@@ -124,9 +124,12 @@ def register_commands():
 
     # Sand command (formerly harvest)
     @bot.tree.command(name="sand", description="Convert spice sand into melange (50:1 ratio)")
-    @app_commands.describe(amount="Amount of spice sand to convert (1-10,000)")
-    async def sand_cmd(interaction: discord.Interaction, amount: int):  # noqa: F841
-        await sand(interaction, amount, True)
+    @app_commands.describe(
+        amount="Amount of spice sand to convert (1-10,000)",
+        landsraad_bonus="Whether or not Landsraad crafting bonus is in effect (default:false)"        
+    )
+    async def sand_cmd(interaction: discord.Interaction, amount: int, landsraad_bonus: bool = False):  # noqa: F841
+        await sand(interaction, amount, landsraad_bonus, True)
 
     # Refinery command
     @bot.tree.command(name="refinery", description="View your melange production and payment status")
@@ -146,20 +149,22 @@ def register_commands():
     @app_commands.describe(
         total_sand="Total spice sand to split and convert",
         users="Users and percentages: '@user1 50 @user2 @user3' (users without % split equally)",
-        guild="Guild cut percentage (default: 10)"
+        guild="Guild cut percentage (default: 10)",
+        landsraad_bonus="Whether or not Landsraad crafting bonus is in effect (default:false)"        
     )
-    async def split_cmd(interaction: discord.Interaction, total_sand: int, users: str, guild: int = 10):  # noqa: F841
-        await split(interaction, total_sand, users, guild, True)
+    async def split_cmd(interaction: discord.Interaction, total_sand: int, users: str, guild: int = 10, landsraad_bonus: bool = False):  # noqa: F841
+        await split(interaction, total_sand, users, guild, landsraad_bonus, True)
 
     # Fixed Rate Cut command
     @bot.tree.command(name="fixedratecut", description="Awards a fixed percentage of spice sand to tagged users")
     @app_commands.describe(
         total_sand="Total spice sand to distribute",
         users="Users to award a cut to",
-        rate="The percentage rate for each user (default: 5)"
+        rate="The percentage rate for each user (default: 5)",
+        landsraad_bonus="Whether or not Landsraad crafting bonus is in effect (default:false)"    
     )
-    async def fixedratecut_cmd(interaction: discord.Interaction, total_sand: int, users: str, rate: int = 5):  # noqa: F841
-        await fixedratecut(interaction, total_sand, users, rate, True)
+    async def fixedratecut_cmd(interaction: discord.Interaction, total_sand: int, users: str, rate: int = 5, landsraad_bonus: bool = False:)  # noqa: F841
+        await fixedratecut(interaction, total_sand, users, rate, landsraad_bonus, True)
 
     # Help command
     @bot.tree.command(name="help", description="Show all available spice tracking commands")

--- a/bot.py
+++ b/bot.py
@@ -163,7 +163,7 @@ def register_commands():
         rate="The percentage rate for each user (default: 5)",
         landsraad_bonus="Whether or not Landsraad crafting bonus is in effect (default:false)"    
     )
-    async def fixedratecut_cmd(interaction: discord.Interaction, total_sand: int, users: str, rate: int = 5, landsraad_bonus: bool = False:)  # noqa: F841
+    async def fixedratecut_cmd(interaction: discord.Interaction, total_sand: int, users: str, rate: int = 5, landsraad_bonus: bool = False)  # noqa: F841
         await fixedratecut(interaction, total_sand, users, rate, landsraad_bonus, True)
 
     # Help command

--- a/commands/expedition.py
+++ b/commands/expedition.py
@@ -10,6 +10,7 @@ COMMAND_METADATA = {
 }
 
 import time
+import math
 from utils.database_utils import timed_database_operation
 from utils.embed_utils import build_status_embed
 from utils.command_utils import log_command_metrics
@@ -22,7 +23,7 @@ from utils.logger import logger
 async def expedition(interaction, expedition_id: int, use_followup: bool = True):
     """View details of a specific expedition"""
     command_start = time.time()
-    
+
     try:
         # Get expedition details using utility function
         expedition_data, get_participants_time = await timed_database_operation(
@@ -30,51 +31,54 @@ async def expedition(interaction, expedition_id: int, use_followup: bool = True)
             get_database().get_expedition_participants,
             expedition_id
         )
-        
+
         if not expedition_data:
             await send_response(interaction, "❌ Expedition not found or you don't have access to it.", use_followup=use_followup, ephemeral=True)
             return
-        
+
         expedition = expedition_data['expedition']
         expedition_participants = expedition_data['participants']
-        
+
         # Calculate guild cut amounts
         guild_cut_percentage = expedition['guild_cut_percentage']
         total_expedition_sand = expedition['total_sand']
         guild_sand = int(total_expedition_sand * (guild_cut_percentage / 100))
         user_sand = total_expedition_sand - guild_sand
-        
+
         # Build participant list
         participant_details = []
         total_participant_sand = 0
-        
+
         for participant in expedition_participants:
             role = "🏭 Primary Harvester" if participant['is_harvester'] else "👥 Expedition Member"
             # Note: Expedition participants show sand allocation, not payment status (payments are user-level)
             participant_details.append(f"{role}: **{participant['username']}**\n"
-                                    f"   Sand: {participant['sand_amount']:,} | Melange: {participant['melange_amount']:,} | Leftover: {participant['leftover_sand']:,}")
+                                    f"   Sand: {participant['sand_amount']:,} | Melange: {participant['melange_amount']:,}")
             total_participant_sand += participant['sand_amount']
-        
+
+        sand_per_melange = expedition['sand_per_melange']
+        guild_melange = math.ceil(guild_sand / sand_per_melange) if sand_per_melange > 0 else 0
+
         # Use utility function for embed building
         fields = {
-            "🏛️ Guild Cut": f"**Guild Cut:** {guild_cut_percentage}% ({guild_sand:,} sand)\n**Guild Melange:** {guild_sand // expedition['sand_per_melange']:,}",
+            "🏛️ Guild Cut": f"**Guild Cut:** {guild_cut_percentage}% ({guild_sand:,} sand)\n**Guild Melange:** {guild_melange:,}",
             "📋 Expedition Participants": "\n\n".join(participant_details) if participant_details else "No participants",
             "📊 Expedition Summary": f"**Initiator:** {expedition['initiator_username']}\n**Total Sand:** {total_expedition_sand:,}\n**User Sand:** {user_sand:,}\n**Participants:** {len(expedition_participants)}"
         }
-        
+
         embed = build_status_embed(
             title=f"🏜️ Expedition #{expedition_id}",
-            description=f"⚗️ **Sand per Melange:** {expedition['sand_per_melange']} | 🗓️ **Created:** {expedition['created_at'].strftime('%Y-%m-%d %H:%M UTC')}",
+            description=f"⚗️ **Sand per Melange:** {sand_per_melange} | 🗓️ **Created:** {expedition['created_at'].strftime('%Y-%m-%d %H:%M UTC')}",
             color=0xF39C12,
             fields=fields,
             timestamp=interaction.created_at
         )
-        
+
         # Send response using helper function
         response_start = time.time()
         await send_response(interaction, embed=embed.build(), use_followup=use_followup)
         response_time = time.time() - response_start
-        
+
         # Log performance metrics using utility function
         total_time = time.time() - command_start
         log_command_metrics(
@@ -90,10 +94,10 @@ async def expedition(interaction, expedition_id: int, use_followup: bool = True)
             guild_cut_percentage=guild_cut_percentage,
             guild_sand=guild_sand
         )
-        
+
     except Exception as error:
         total_time = time.time() - command_start
-        logger.error(f"Error in expedition command: {error}", 
+        logger.error(f"Error in expedition command: {error}",
                     user_id=str(interaction.user.id),
                     username=interaction.user.display_name,
                     expedition_id=expedition_id,

--- a/commands/fixedratecut.py
+++ b/commands/fixedratecut.py
@@ -9,7 +9,8 @@ COMMAND_METADATA = {
     'params': {
         'total_sand': "Total spice sand collected to be distributed.",
         'users': "A list of users to award a cut to.",
-        'rate': "The percentage rate of the cut for each user (default: 5)."
+        'rate': "The percentage rate of the cut for each user (default: 5).",
+        'landsraad_bonus': "Whether or not to apply the 25% Landsraad crafting reduction (default: false)."
     }
 }
 

--- a/commands/fixedratecut.py
+++ b/commands/fixedratecut.py
@@ -1,0 +1,164 @@
+"""
+Fixed rate cut command for awarding a percentage of spice sand to users and the rest to the guild.
+"""
+
+# Command metadata
+COMMAND_METADATA = {
+    'aliases': ['frc'],
+    'description': "Awards a fixed percentage of spice sand to tagged users, with the remainder going to the guild.",
+    'params': {
+        'total_sand': "Total spice sand collected to be distributed.",
+        'users': "A list of users to award a cut to.",
+        'rate': "The percentage rate of the cut for each user (default: 5)."
+    }
+}
+
+import re
+import traceback
+import discord
+from utils.decorators import handle_interaction_expiration
+from utils.helpers import get_database, get_sand_per_melange, send_response
+from utils.logger import logger
+
+@handle_interaction_expiration
+async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, use_followup: bool = True):
+    """Awards a fixed percentage of spice sand to tagged users, with the remainder going to the guild."""
+    try:
+        # Validate inputs
+        if total_sand < 1:
+            await send_response(interaction, "❌ Total spice sand must be at least 1.", use_followup=use_followup, ephemeral=True)
+            return
+
+        if not 0 <= rate <= 100:
+            await send_response(interaction, "❌ Rate must be between 0 and 100.", use_followup=use_followup, ephemeral=True)
+            return
+
+        # Parse users string for mentions
+        pattern = r'<@!?(\d+)>'
+        user_ids = re.findall(pattern, users)
+
+        if not user_ids:
+            await send_response(interaction,
+                "❌ Please provide valid Discord user mentions.\n\n"
+                "**Example:**\n"
+                "• `/fixedratecut total_sand:10000 users:\"@user1 @user2\" rate:10`",
+                use_followup=use_followup, ephemeral=True)
+            return
+
+        # Remove duplicate user_ids
+        user_ids = list(set(user_ids))
+        num_users = len(user_ids)
+
+        if num_users * rate > 100:
+            await send_response(interaction, f"❌ The total cut for all users ({num_users} * {rate}% = {num_users * rate}%) cannot exceed 100%.", use_followup=use_followup, ephemeral=True)
+            return
+
+        # Calculations
+        user_sand = int(total_sand * (rate / 100))
+        total_user_sand = user_sand * num_users
+        guild_sand = total_sand - total_user_sand
+
+        # Get conversion rate
+        sand_per_melange = get_sand_per_melange()
+
+        # Ensure the initiator exists in the users table
+        from utils.database_utils import validate_user_exists
+        await validate_user_exists(get_database(), str(interaction.user.id), interaction.user.display_name)
+
+        # Create expedition record
+        expedition_id = await get_database().create_expedition(
+            str(interaction.user.id),
+            interaction.user.display_name,
+            total_sand,
+            sand_per_melange=sand_per_melange,
+            guild_cut_percentage=(guild_sand / total_sand * 100) if total_sand > 0 else 0
+        )
+
+        if not expedition_id:
+            await send_response(interaction, "❌ Failed to create expedition record.", use_followup=use_followup, ephemeral=True)
+            return
+
+        # Add guild cut to treasury if > 0
+        if guild_sand > 0:
+            guild_melange = guild_sand // sand_per_melange
+            await get_database().update_guild_treasury(guild_sand, guild_melange)
+
+        # Process all participants
+        participant_details = []
+        total_user_melange = 0
+
+        for user_id in user_ids:
+            try:
+                # Try to get user from guild first, then client
+                try:
+                    user = await interaction.guild.fetch_member(int(user_id))
+                    display_name = user.display_name
+                except (discord.NotFound, discord.HTTPException):
+                    try:
+                        user = await interaction.client.fetch_user(int(user_id))
+                        display_name = user.display_name
+                    except (discord.NotFound, discord.HTTPException):
+                        display_name = f"User_{user_id}"
+
+                # Ensure user exists in database
+                await validate_user_exists(get_database(), user_id, display_name)
+
+                # Calculate melange and leftover sand
+                participant_melange = user_sand // sand_per_melange
+                participant_leftover = user_sand % sand_per_melange
+                total_user_melange += participant_melange
+
+                # Add expedition participant
+                await get_database().add_expedition_participant(
+                    expedition_id, user_id, display_name, user_sand,
+                    participant_melange, participant_leftover, is_harvester=False
+                )
+
+                # Add deposit record
+                await get_database().add_deposit(user_id, display_name, user_sand, expedition_id=expedition_id)
+
+                # Update user's melange total if they earned melange
+                if participant_melange > 0:
+                    await get_database().update_user_melange(user_id, participant_melange)
+
+                # Format for display
+                participant_details.append(f"**{display_name}**: {user_sand:,} sand ({participant_melange:,} melange)")
+
+            except Exception as participant_error:
+                logger.error(f"Error processing participant {user_id}: {participant_error}")
+                participant_details.append(f"**User_{user_id}**: {user_sand:,} sand (error processing)")
+
+        # Build response embed
+        from utils.embed_utils import build_status_embed
+
+        guild_cut_percentage = (guild_sand / total_sand * 100) if total_sand > 0 else 0
+
+        fields = {
+            "👥 Participants": "\n".join(participant_details),
+            "🏛️ Guild Cut": f"**{guild_cut_percentage:.1f}%** = {guild_sand:,} sand → **{guild_sand // sand_per_melange:,} melange**",
+            "📊 Summary": f"**Total:** {total_sand:,} | **Users:** {total_user_sand:,} sand → **{total_user_melange:,} melange**"
+        }
+
+        embed = build_status_embed(
+            title="💸 Fixed Rate Cut Completed",
+            description=f"**Expedition #{expedition_id}** - {num_users} participants at a {rate}% rate.",
+            color=0x00FF00,
+            fields=fields,
+            timestamp=interaction.created_at
+        )
+
+        # Send response
+        await send_response(interaction, embed=embed.build(), use_followup=use_followup)
+
+        # Log the expedition creation
+        logger.info(f"Fixed Rate Cut {expedition_id} created by {interaction.user.display_name} ({interaction.user.id})",
+                   total_sand=total_sand, guild_sand=guild_sand, participants=num_users, rate=rate)
+
+    except Exception as error:
+        logger.error(f"Error in fixedratecut command: {error}")
+        logger.error(f"Fixedratecut command traceback: {traceback.format_exc()}")
+
+        try:
+            await send_response(interaction, "❌ An error occurred while processing the fixed rate cut. Please try again.", use_followup=use_followup, ephemeral=True)
+        except Exception as response_error:
+            logger.error(f"Failed to send error response: {response_error}")

--- a/commands/fixedratecut.py
+++ b/commands/fixedratecut.py
@@ -21,7 +21,7 @@ from utils.helpers import get_database, get_sand_per_melange, send_response
 from utils.logger import logger
 
 @handle_interaction_expiration
-async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, use_followup: bool = True):
+async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, landsraad_bonus: bool = False, use_followup: bool = True):
     """Awards a fixed percentage of spice sand to tagged users, with the remainder going to the guild."""
     try:
         # Validate inputs
@@ -59,7 +59,7 @@ async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, 
         guild_sand = total_sand - total_user_sand
 
         # Get conversion rate
-        sand_per_melange = get_sand_per_melange()
+        sand_per_melange = get_sand_per_melange(landsraad_bonus=landsraad_bonus)
 
         # Ensure the initiator exists in the users table
         from utils.database_utils import validate_user_exists

--- a/commands/fixedratecut.py
+++ b/commands/fixedratecut.py
@@ -17,6 +17,7 @@ COMMAND_METADATA = {
 import re
 import traceback
 import discord
+import math
 from utils.decorators import handle_interaction_expiration
 from utils.helpers import get_database, get_sand_per_melange, send_response
 from utils.logger import logger
@@ -81,7 +82,7 @@ async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, 
 
         # Add guild cut to treasury if > 0
         if guild_sand > 0:
-            guild_melange = guild_sand // sand_per_melange
+            guild_melange = math.ceil(guild_sand / sand_per_melange) if sand_per_melange > 0 else 0
             await get_database().update_guild_treasury(guild_sand, guild_melange)
 
         # Process all participants
@@ -104,15 +105,14 @@ async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, 
                 # Ensure user exists in database
                 await validate_user_exists(get_database(), user_id, display_name)
 
-                # Calculate melange and leftover sand
-                participant_melange = user_sand // sand_per_melange
-                participant_leftover = user_sand % sand_per_melange
+                # Calculate melange
+                participant_melange = math.ceil(user_sand / sand_per_melange) if sand_per_melange > 0 else 0
                 total_user_melange += participant_melange
 
                 # Add expedition participant
                 await get_database().add_expedition_participant(
                     expedition_id, user_id, display_name, user_sand,
-                    participant_melange, participant_leftover, is_harvester=False
+                    participant_melange, is_harvester=False
                 )
 
                 # Add deposit record
@@ -133,10 +133,11 @@ async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, 
         from utils.embed_utils import build_status_embed
 
         guild_cut_percentage = (guild_sand / total_sand * 100) if total_sand > 0 else 0
+        guild_melange_total = math.ceil(guild_sand / sand_per_melange) if sand_per_melange > 0 else 0
 
         fields = {
             "👥 Participants": "\n".join(participant_details),
-            "🏛️ Guild Cut": f"**{guild_cut_percentage:.1f}%** = {guild_sand:,} sand → **{guild_sand // sand_per_melange:,} melange**",
+            "🏛️ Guild Cut": f"**{guild_cut_percentage:.1f}%** = {guild_sand:,} sand → **{guild_melange_total:,} melange**",
             "📊 Summary": f"**Total:** {total_sand:,} | **Users:** {total_user_sand:,} sand → **{total_user_melange:,} melange**"
         }
 

--- a/commands/help.py
+++ b/commands/help.py
@@ -26,6 +26,7 @@ async def help(interaction, use_followup: bool = True):
                                  "**`/expedition [id]`** View expedition details\n"
                                  "**`/leaderboard [limit]`** Top refiners (5-25 users)\n"
                                  "**`/split [sand] [@users]`** Split sand→melange with guild cut\n"
+                                 "**`/fixedratecut [sand] [@users] [optional: fixed rate percent Default - 5]`** Split a fixed percentage of sand→melange between users with leftover going to guild\n"
                                  "**`/help`** Show all commands",
         "⚙️ Admin Commands": "**`/pending`** View pending melange payments\n"
                                    "**`/pay [user] [amount]`** Process user payment (full or partial)\n"
@@ -37,6 +38,7 @@ async def help(interaction, use_followup: bool = True):
 
         "💡 Examples": "• `/sand 250` → 5 melange\n"
                             "• `/split 1000 @user1 @user2` → 500 each\n"
+                            "• `/fixedratecut 75000 @user1 @user2 10` → 7500 sand/150 melange each\n"
                             "• `/pay @user` → pay pending melange\n"
                             "• `/payroll` → pay all users"
     }
@@ -50,3 +52,4 @@ async def help(interaction, use_followup: bool = True):
     )
     
     await send_response(interaction, embed=embed.build(), use_followup=use_followup, ephemeral=True)
+

--- a/commands/sand.py
+++ b/commands/sand.py
@@ -6,7 +6,8 @@ Sand command for logging spice sand harvests and calculating melange conversion.
 COMMAND_METADATA = {
     'aliases': [],  # formerly named 'harvest'
     'description': "Convert spice sand into melange (primary currency)",
-    'params': {'amount': "Amount of spice sand to convert"}
+    'params': {'amount': "Amount of spice sand to convert",
+    'landsraad_bonus': "Whether or not to apply the 25% Landsraad crafting reduction (default: false)."}
 }
 
 import time
@@ -90,3 +91,4 @@ async def sand(interaction, amount: int, landsraad_bonus: bool = False, use_foll
         response_time=f"{response_time:.3f}s",
         new_melange=new_melange
     )
+

--- a/commands/sand.py
+++ b/commands/sand.py
@@ -6,8 +6,9 @@ Sand command for logging spice sand harvests and calculating melange conversion.
 COMMAND_METADATA = {
     'aliases': [],  # formerly named 'harvest'
     'description': "Convert spice sand into melange (primary currency)",
-    'params': {'amount': "Amount of spice sand to convert",
-    'landsraad_bonus': "Whether or not to apply the 25% Landsraad crafting reduction (default: false)."}
+    'params': {
+        'amount': "Amount of spice sand to convert",
+        'landsraad_bonus': "Whether or not to apply the 25% Landsraad crafting reduction (default: false)." }
 }
 
 import time
@@ -91,4 +92,5 @@ async def sand(interaction, amount: int, landsraad_bonus: bool = False, use_foll
         response_time=f"{response_time:.3f}s",
         new_melange=new_melange
     )
+
 

--- a/commands/sand.py
+++ b/commands/sand.py
@@ -12,6 +12,7 @@ COMMAND_METADATA = {
 }
 
 import time
+import math
 from utils.database_utils import timed_database_operation, validate_user_exists
 from utils.embed_utils import build_status_embed
 from utils.command_utils import log_command_metrics
@@ -23,31 +24,31 @@ from utils.helpers import get_database, get_sand_per_melange, send_response
 async def sand(interaction, amount: int, landsraad_bonus: bool = False, use_followup: bool = True):
     """Convert spice sand into melange (primary currency)"""
     command_start = time.time()
-    
+
     # Validate amount
     if not 1 <= amount <= 10000:
         await send_response(interaction, "❌ Amount must be between 1 and 10,000 spice sand.", use_followup=use_followup, ephemeral=True)
         return
-    
+
     # Get conversion rate and add deposit
     sand_per_melange = get_sand_per_melange(landsraad_bonus=landsraad_bonus)
-    
+
     # Database operations with timing using utility functions
-    
+
     # Add deposit with timing
     _, add_deposit_time = await timed_database_operation(
         "add_deposit",
         get_database().add_deposit,
         str(interaction.user.id), interaction.user.display_name, amount
     )
-    
+
     # Ensure user exists and get their data
     user = await validate_user_exists(get_database(), str(interaction.user.id), interaction.user.display_name)
-    
+
     # Convert sand directly to melange
-    new_melange = amount // sand_per_melange
+    new_melange = math.ceil(amount / sand_per_melange) if sand_per_melange > 0 else 0
     current_melange = user.get('total_melange', 0)
-    
+
     # Only update melange if we have new melange to add
     update_melange_time = 0
     if new_melange > 0:
@@ -56,16 +57,15 @@ async def sand(interaction, amount: int, landsraad_bonus: bool = False, use_foll
             get_database().update_user_melange,
             str(interaction.user.id), new_melange
         )
-    
+
     # Build concise response
-    leftover_sand = amount % sand_per_melange
     description = f"🎉 **+{new_melange:,} melange**" if new_melange > 0 else f"📦 **{amount:,} sand processed**"
-    
+
     fields = {
         "💎 Total": f"{(current_melange + new_melange):,} melange",
-        "⚙️ Converted": f"{amount:,} sand → {new_melange:,} melange" + (f" ({leftover_sand} unused)" if leftover_sand > 0 else "")
+        "⚙️ Converted": f"{amount:,} sand → {new_melange:,} melange"
     }
-    
+
     embed = build_status_embed(
         title="🏜️ Conversion Complete",
         description=description,
@@ -73,12 +73,12 @@ async def sand(interaction, amount: int, landsraad_bonus: bool = False, use_foll
         fields=fields,
         timestamp=interaction.created_at
     )
-    
+
     # Send response using helper function
     response_start = time.time()
     await send_response(interaction, embed=embed.build(), use_followup=use_followup)
     response_time = time.time() - response_start
-    
+
     # Log performance metrics using utility function
     total_time = time.time() - command_start
     log_command_metrics(
@@ -92,5 +92,3 @@ async def sand(interaction, amount: int, landsraad_bonus: bool = False, use_foll
         response_time=f"{response_time:.3f}s",
         new_melange=new_melange
     )
-
-

--- a/commands/sand.py
+++ b/commands/sand.py
@@ -18,7 +18,7 @@ from utils.helpers import get_database, get_sand_per_melange, send_response
 
 
 @handle_interaction_expiration
-async def sand(interaction, amount: int, use_followup: bool = True):
+async def sand(interaction, amount: int, landsraad_bonus: bool = False, use_followup: bool = True):
     """Convert spice sand into melange (primary currency)"""
     command_start = time.time()
     
@@ -28,7 +28,7 @@ async def sand(interaction, amount: int, use_followup: bool = True):
         return
     
     # Get conversion rate and add deposit
-    sand_per_melange = get_sand_per_melange()
+    sand_per_melange = get_sand_per_melange(landsraad_bonus=landsraad_bonus)
     
     # Database operations with timing using utility functions
     

--- a/commands/split.py
+++ b/commands/split.py
@@ -22,7 +22,7 @@ from utils.logger import logger
 
 
 @handle_interaction_expiration
-async def split(interaction, total_sand: int, users: str, guild: int = 10, use_followup: bool = True):
+async def split(interaction, total_sand: int, users: str, guild: int = 10, landsraad_bonus: bool = False, use_followup: bool = True):
     """Split spice sand among expedition members and convert to melange with guild cut"""
     
     try:
@@ -113,7 +113,7 @@ async def split(interaction, total_sand: int, users: str, guild: int = 10, use_f
             return
         
         # Get conversion rate
-        sand_per_melange = get_sand_per_melange()
+        sand_per_melange = get_sand_per_melange(landsraad_bonus=landsraad_bonus)
         
         # Ensure the initiator exists in the users table
         from utils.database_utils import validate_user_exists

--- a/commands/split.py
+++ b/commands/split.py
@@ -9,8 +9,8 @@ COMMAND_METADATA = {
     'params': {
         'total_sand': "Total spice sand collected to split",
         'users': "Users and percentages: '@user1 50 @user2 @user3' (users without % split equally)",
-        'guild': "Guild cut percentage (default: 10)"
-    }
+        'guild': "Guild cut percentage (default: 10)",
+        'landsraad_bonus': "Whether or not to apply the 25% Landsraad crafting reduction (default: false)."    }
 }
 
 import re
@@ -214,4 +214,5 @@ async def split(interaction, total_sand: int, users: str, guild: int = 10, lands
         try:
             await send_response(interaction, "❌ An error occurred while processing the split. Please try again.", use_followup=use_followup, ephemeral=True)
         except Exception as response_error:
+
             logger.error(f"Failed to send error response: {response_error}")

--- a/commands/split.py
+++ b/commands/split.py
@@ -16,6 +16,7 @@ COMMAND_METADATA = {
 import re
 import traceback
 import discord
+import math
 from utils.decorators import handle_interaction_expiration
 from utils.helpers import get_database, get_sand_per_melange, send_response
 from utils.logger import logger
@@ -24,38 +25,38 @@ from utils.logger import logger
 @handle_interaction_expiration
 async def split(interaction, total_sand: int, users: str, guild: int = 10, landsraad_bonus: bool = False, use_followup: bool = True):
     """Split spice sand among expedition members and convert to melange with guild cut"""
-    
+
     try:
         # Validate inputs
         if total_sand < 1:
             await send_response(interaction, "❌ Total spice sand must be at least 1.", use_followup=use_followup, ephemeral=True)
             return
-        
+
         if not 0 <= guild <= 100:
             await send_response(interaction, "❌ Guild cut percentage must be between 0 and 100.", use_followup=use_followup, ephemeral=True)
             return
-        
+
         # Parse users string for mentions and percentages
         # Format: "@user1 50 @user2 @user3 25" etc.
         user_data = []
         percentage_users = []
         equal_split_users = []
-        
+
         # Extract user mentions and optional percentages
         # Pattern: @user_id optionally followed by a number
         pattern = r'<@!?(\d+)>\s*(\d+)?'
         matches = re.findall(pattern, users)
-        
+
         if not matches:
-            await send_response(interaction, 
+            await send_response(interaction,
                 "❌ Please provide valid Discord user mentions.\n\n"
                 "**Examples:**\n"
                 "• Equal split: `/split total_sand:1000 users:\"@user1 @user2\"`\n"
                 "• Percentage split: `/split total_sand:1000 users:\"@leader 60 @member1 @member2\"`\n"
-                "• Mixed: `/split total_sand:1000 users:\"@leader 40 @member1 @member2\" guild:5`", 
+                "• Mixed: `/split total_sand:1000 users:\"@leader 40 @member1 @member2\" guild:5`",
                 use_followup=use_followup, ephemeral=True)
             return
-        
+
         total_percentage = 0
         for user_id, percentage_str in matches:
             if percentage_str:  # User has a percentage
@@ -67,37 +68,37 @@ async def split(interaction, total_sand: int, users: str, guild: int = 10, lands
                 total_percentage += percentage
             else:  # User will get equal split
                 equal_split_users.append(user_id)
-        
+
         # Validate percentages don't exceed 100%
         if total_percentage > 100:
             await send_response(interaction, f"❌ Total user percentages ({total_percentage}%) cannot exceed 100%.", use_followup=use_followup, ephemeral=True)
             return
-        
+
         # Calculate guild cut first
         guild_sand = int(total_sand * (guild / 100))
         remaining_sand = total_sand - guild_sand
-        
+
         # Calculate user distributions
         user_distributions = []
         remaining_after_percentages = remaining_sand
-        
+
         # First, allocate to percentage users
         for user_id, percentage in percentage_users:
             user_sand = int(remaining_sand * (percentage / 100))
             user_distributions.append((user_id, user_sand, percentage))
             remaining_after_percentages -= user_sand
-        
+
         # Then, split remaining sand equally among non-percentage users
         if equal_split_users:
             equal_share = remaining_after_percentages // len(equal_split_users)
             leftover = remaining_after_percentages % len(equal_split_users)
-            
+
             for i, user_id in enumerate(equal_split_users):
                 # Give leftover sand to first few users
                 user_sand = equal_share + (1 if i < leftover else 0)
                 equal_percentage = (user_sand / remaining_sand) * 100 if remaining_sand > 0 else 0
                 user_distributions.append((user_id, user_sand, equal_percentage))
-        
+
         # Remove duplicates and validate we have users
         unique_distributions = {}
         for user_id, sand, percentage in user_distributions:
@@ -107,18 +108,18 @@ async def split(interaction, total_sand: int, users: str, guild: int = 10, lands
                 unique_distributions[user_id] = (existing_sand + sand, existing_pct + percentage)
             else:
                 unique_distributions[user_id] = (sand, percentage)
-        
+
         if not unique_distributions:
             await send_response(interaction, "❌ No valid users found to split with.", use_followup=use_followup, ephemeral=True)
             return
-        
+
         # Get conversion rate
         sand_per_melange = get_sand_per_melange(landsraad_bonus=landsraad_bonus)
-        
+
         # Ensure the initiator exists in the users table
         from utils.database_utils import validate_user_exists
         await validate_user_exists(get_database(), str(interaction.user.id), interaction.user.display_name)
-        
+
         # Create expedition record with guild cut
         expedition_id = await get_database().create_expedition(
             str(interaction.user.id),
@@ -127,20 +128,20 @@ async def split(interaction, total_sand: int, users: str, guild: int = 10, lands
             sand_per_melange=sand_per_melange,
             guild_cut_percentage=guild
         )
-        
+
         if not expedition_id:
             await send_response(interaction, "❌ Failed to create expedition record.", use_followup=use_followup, ephemeral=True)
             return
-        
+
         # Add guild cut to treasury if > 0
         if guild_sand > 0:
-            guild_melange = guild_sand // sand_per_melange
+            guild_melange = math.ceil(guild_sand / sand_per_melange) if sand_per_melange > 0 else 0
             await get_database().update_guild_treasury(guild_sand, guild_melange)
-        
+
         # Process all participants
         participant_details = []
         total_user_melange = 0
-        
+
         for user_id, (user_sand, user_percentage) in unique_distributions.items():
             try:
                 # Try to get user from guild first, then client
@@ -153,45 +154,46 @@ async def split(interaction, total_sand: int, users: str, guild: int = 10, lands
                         display_name = user.display_name
                     except:
                         display_name = f"User_{user_id}"
-                
+
                 # Ensure user exists in database
                 await validate_user_exists(get_database(), user_id, display_name)
-                
-                # Calculate melange and leftover sand
-                participant_melange = user_sand // sand_per_melange
-                participant_leftover = user_sand % sand_per_melange
+
+                # Calculate melange
+                participant_melange = math.ceil(user_sand / sand_per_melange) if sand_per_melange > 0 else 0
                 total_user_melange += participant_melange
-                
+
                 # Add expedition participant
                 await get_database().add_expedition_participant(
-                    expedition_id, user_id, display_name, user_sand, 
-                    participant_melange, participant_leftover, is_harvester=False
+                    expedition_id, user_id, display_name, user_sand,
+                    participant_melange, is_harvester=False
                 )
-                
+
                 # Add deposit record
                 await get_database().add_deposit(user_id, display_name, user_sand, expedition_id=expedition_id)
-                
+
                 # Update user's melange total if they earned melange
                 if participant_melange > 0:
                     await get_database().update_user_melange(user_id, participant_melange)
-                
+
                 # Format for display
                 percentage_text = f" ({user_percentage:.1f}%)" if user_percentage > 0 else ""
                 participant_details.append(f"**{display_name}**: {user_sand:,} sand ({participant_melange:,} melange){percentage_text}")
-                
+
             except Exception as participant_error:
                 logger.error(f"Error processing participant {user_id}: {participant_error}")
                 participant_details.append(f"**User_{user_id}**: {user_sand:,} sand (error processing)")
-        
+
         # Build response embed
         from utils.embed_utils import build_status_embed
-        
+
+        guild_melange_total = math.ceil(guild_sand / sand_per_melange) if sand_per_melange > 0 else 0
+
         fields = {
             "👥 Participants": "\n".join(participant_details),
-            "🏛️ Guild Cut": f"**{guild}%** = {guild_sand:,} sand → **{guild_sand // sand_per_melange:,} melange**",
+            "🏛️ Guild Cut": f"**{guild}%** = {guild_sand:,} sand → **{guild_melange_total:,} melange**",
             "📊 Summary": f"**Total:** {total_sand:,} | **Users:** {remaining_sand:,} sand → **{total_user_melange:,} melange**"
         }
-        
+
         embed = build_status_embed(
             title="🏜️ Expedition Split Completed",
             description=f"**Expedition #{expedition_id}** - {len(unique_distributions)} participants",
@@ -199,18 +201,18 @@ async def split(interaction, total_sand: int, users: str, guild: int = 10, lands
             fields=fields,
             timestamp=interaction.created_at
         )
-        
+
         # Send response
         await send_response(interaction, embed=embed.build(), use_followup=use_followup)
-        
+
         # Log the expedition creation
-        logger.info(f"Expedition {expedition_id} created by {interaction.user.display_name} ({interaction.user.id})", 
+        logger.info(f"Expedition {expedition_id} created by {interaction.user.display_name} ({interaction.user.id})",
                    total_sand=total_sand, guild_cut=guild_sand, participants=len(unique_distributions))
-        
+
     except Exception as error:
         logger.error(f"Error in split command: {error}")
         logger.error(f"Split command traceback: {traceback.format_exc()}")
-        
+
         try:
             await send_response(interaction, "❌ An error occurred while processing the split. Please try again.", use_followup=use_followup, ephemeral=True)
         except Exception as response_error:

--- a/database.py
+++ b/database.py
@@ -335,15 +335,15 @@ class Database:
                                         operation="withdrawal", sand_amount=sand_amount, target_user_id=target_user_id, error=str(e))
                 raise e
 
-    async def add_expedition_participant(self, expedition_id, user_id, username, sand_amount, melange_amount, leftover_sand, is_harvester=False):
+    async def add_expedition_participant(self, expedition_id, user_id, username, sand_amount, melange_amount, is_harvester=False):
         """Add a participant to an expedition"""
         start_time = time.time()
         async with self._get_connection() as conn:
             try:
                 await conn.execute('''
-                    INSERT INTO expedition_participants (expedition_id, user_id, username, sand_amount, melange_amount, leftover_sand, is_harvester)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7)
-                ''', expedition_id, user_id, username, sand_amount, melange_amount, leftover_sand, is_harvester)
+                    INSERT INTO expedition_participants (expedition_id, user_id, username, sand_amount, melange_amount, is_harvester)
+                    VALUES ($1, $2, $3, $4, $5, $6)
+                ''', expedition_id, user_id, username, sand_amount, melange_amount, is_harvester)
                 
                 await self._log_operation("insert", "expedition_participants", start_time, success=True, 
                                         expedition_id=expedition_id, user_id=user_id, sand_amount=sand_amount, is_harvester=is_harvester)
@@ -405,8 +405,7 @@ class Database:
                         'username': row[3],
                         'sand_amount': row[4],
                         'melange_amount': row[5],
-                        'leftover_sand': row[6],
-                        'is_harvester': bool(row[7])
+                        'is_harvester': bool(row[6])
                     })
                 
                 # Combine expedition details with participants
@@ -816,4 +815,5 @@ class Database:
             except Exception as e:
                 await self._log_operation("select_join", "deposits_users", start_time, success=False, 
                                         error=str(e))
+
                 raise e

--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,7 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'spice-tracker-bot-tma'
+app = 'spice-tracker-bot-wlpasq'
 primary_region = 'iad'
 
 [build]

--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,7 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'spice-tracker-bot-wlpasq'
+app = 'spice-tracker-bot-tma'
 primary_region = 'iad'
 
 [build]

--- a/supabase/migrations/20250904124600_update_sand_per_melange_type.sql
+++ b/supabase/migrations/20250904124600_update_sand_per_melange_type.sql
@@ -1,0 +1,9 @@
+-- Update sand_per_melange to REAL and remove leftover_sand
+
+-- Alter the expeditions table to change the data type of sand_per_melange
+ALTER TABLE expeditions
+ALTER COLUMN sand_per_melange TYPE REAL;
+
+-- Alter the expedition_participants table to remove the leftover_sand column
+ALTER TABLE expedition_participants
+DROP COLUMN leftover_sand;

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -52,7 +52,7 @@ class TestCommandDiscovery:
         expected_commands = {
             'sand', 'refinery', 'leaderboard',
             'split', 'help', 'reset', 'ledger', 'expedition',
-            'payment', 'payroll', 'treasury', 'guild_withdraw', 'pending'
+            'payment', 'payroll', 'treasury', 'guild_withdraw', 'pending', 'fixedratecut'
         }
         
         discovered_commands = set(COMMAND_METADATA.keys())

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -111,6 +111,39 @@ class TestCommandResponsiveness:
             except Exception as e:
                 pytest.fail(f"Command {function_name} failed with error on invalid input: {e}")
 
+    @pytest.mark.asyncio
+    async def test_landsraad_bonus_sand_command(self, mock_interaction, mock_database):
+        """Test the sand command with the landsraad_bonus flag."""
+        from commands.sand import sand
+        with patch('commands.sand.get_sand_per_melange') as mock_get_sand_per_melange, \
+             patch('commands.sand.get_database', return_value=mock_database):
+
+            mock_get_sand_per_melange.return_value = 37
+            await sand(mock_interaction, 100, landsraad_bonus=True)
+            mock_get_sand_per_melange.assert_called_with(landsraad_bonus=True)
+
+    @pytest.mark.asyncio
+    async def test_landsraad_bonus_split_command(self, mock_interaction, mock_database):
+        """Test the split command with the landsraad_bonus flag."""
+        from commands.split import split
+        with patch('commands.split.get_sand_per_melange') as mock_get_sand_per_melange, \
+             patch('commands.split.get_database', return_value=mock_database):
+
+            mock_get_sand_per_melange.return_value = 37
+            await split(mock_interaction, 1000, '<@12345>', 10, landsraad_bonus=True)
+            mock_get_sand_per_melange.assert_called_with(landsraad_bonus=True)
+
+    @pytest.mark.asyncio
+    async def test_landsraad_bonus_fixedratecut_command(self, mock_interaction, mock_database):
+        """Test the fixedratecut command with the landsraad_bonus flag."""
+        from commands.fixedratecut import fixedratecut
+        with patch('commands.fixedratecut.get_sand_per_melange') as mock_get_sand_per_melange, \
+             patch('commands.fixedratecut.get_database', return_value=mock_database):
+
+            mock_get_sand_per_melange.return_value = 37
+            await fixedratecut(mock_interaction, 10000, '<@12345>', 5, landsraad_bonus=True)
+            mock_get_sand_per_melange.assert_called_with(landsraad_bonus=True)
+
     def test_command_metadata_structure(self):
         """Test that all commands have proper metadata structure."""
         for command_name, metadata in COMMAND_METADATA.items():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,7 +8,7 @@ from commands import COMMAND_METADATA
 
 class TestCommandResponsiveness:
     """Test that all commands respond appropriately."""
-    
+
     @pytest.mark.asyncio
     async def test_all_commands_respond(self, mock_interaction, mock_database):
         """Test that all commands can execute and respond without crashing."""
@@ -19,6 +19,7 @@ class TestCommandResponsiveness:
             ('leaderboard', 'leaderboard', [10, True], {}),
 
             ('split', 'split', [1000, '@user1 @user2', True], {}),
+            ('fixedratecut', 'fixedratecut', [10000, '<@12345>', 5, True], {}),
             ('help', 'help', [True], {}),
             ('reset', 'reset', [True, True], {}),
             ('ledger', 'ledger', [True], {}),
@@ -26,12 +27,12 @@ class TestCommandResponsiveness:
             ('payment', 'pay', [Mock(id=123, display_name="TestUser"), None, True], {}),
             ('payroll', 'payroll', [True], {}),
         ]
-        
+
         for module_name, function_name, args, kwargs in test_cases:
             try:
                 # Get the command function
                 command_func = getattr(__import__(f'commands.{module_name}', fromlist=[module_name]), function_name)
-                
+
                 # Mock the database for this command - try different import paths
                 try:
                     with patch(f'commands.{module_name}.get_database', return_value=mock_database):
@@ -40,26 +41,26 @@ class TestCommandResponsiveness:
                     # Try patching utils.helpers.get_database instead
                     with patch('utils.helpers.get_database', return_value=mock_database):
                         await command_func(mock_interaction, *args, **kwargs)
-                
+
                 # Verify some form of response was sent (either followup.send or response.send)
                 response_sent = (
-                    mock_interaction.followup.send.called or 
+                    mock_interaction.followup.send.called or
                     mock_interaction.response.send.called or
                     mock_interaction.channel.send.called or
                     mock_interaction.response.send_modal.called
                 )
-                
+
                 assert response_sent, f"Command {function_name} did not send any response"
-                
+
                 # Reset mocks for next test
                 mock_interaction.followup.send.reset_mock()
                 mock_interaction.response.send.reset_mock()
                 mock_interaction.channel.send.reset_mock()
                 mock_interaction.response.send_modal.reset_mock()
-                
+
             except Exception as e:
                 pytest.fail(f"Command {function_name} failed with error: {e}")
-    
+
     @pytest.mark.asyncio
     async def test_commands_with_invalid_inputs(self, mock_interaction, mock_database):
         """Test that commands handle invalid inputs gracefully."""
@@ -69,14 +70,19 @@ class TestCommandResponsiveness:
             ('sand', 'sand', [15000, True], {}),  # Too high
             ('split', 'split', [0, '@user1', True], {}),  # Invalid sand amount
             ('split', 'split', [1000, '@user1', True], {}),  # Valid split
+            ('fixedratecut', 'fixedratecut', [0, '@user1', 5, True], {}),
+            ('fixedratecut', 'fixedratecut', [1000, '@user1', -1, True], {}),
+            ('fixedratecut', 'fixedratecut', [1000, '@user1', 101, True], {}),
+            ('fixedratecut', 'fixedratecut', [1000, '', 5, True], {}),
+            ('fixedratecut', 'fixedratecut', [1000, '<@1> <@2> <@3> <@4> <@5> <@6> <@7> <@8> <@9> <@10> <@11> <@12> <@13> <@14> <@15> <@16> <@17> <@18> <@19> <@20> <@21>', 5, True], {}),
             ('reset', 'reset', [False, True], {}),  # Not confirmed
         ]
-        
+
         for module_name, function_name, args, kwargs in edge_cases:
             try:
                 # Get the command function
                 command_func = getattr(__import__(f'commands.{module_name}', fromlist=[module_name]), function_name)
-                
+
                 # Mock the database for this command - try different import paths
                 try:
                     with patch(f'commands.{module_name}.get_database', return_value=mock_database):
@@ -85,48 +91,49 @@ class TestCommandResponsiveness:
                     # Try patching utils.helpers.get_database instead
                     with patch('utils.helpers.get_database', return_value=mock_database):
                         await command_func(mock_interaction, *args, **kwargs)
-                
+
                 # Verify some form of response was sent
                 response_sent = (
-                    mock_interaction.followup.send.called or 
+                    mock_interaction.followup.send.called or
                     mock_interaction.response.send.called or
                     mock_interaction.channel.send.called or
                     mock_interaction.response.send_modal.called
                 )
-                
+
                 assert response_sent, f"Command {function_name} did not send any response to invalid input"
-                
+
                 # Reset mocks for next test
                 mock_interaction.followup.send.reset_mock()
                 mock_interaction.response.send.reset_mock()
                 mock_interaction.channel.send.reset_mock()
                 mock_interaction.response.send_modal.reset_mock()
-                
+
             except Exception as e:
                 pytest.fail(f"Command {function_name} failed with error on invalid input: {e}")
-    
+
     def test_command_metadata_structure(self):
         """Test that all commands have proper metadata structure."""
         for command_name, metadata in COMMAND_METADATA.items():
             # Check required metadata fields
             assert 'description' in metadata, f"Command {command_name} missing description"
             assert isinstance(metadata['description'], str), f"Command {command_name} description must be string"
-            
+
             # Check optional fields if present
             if 'aliases' in metadata:
                 assert isinstance(metadata['aliases'], list), f"Command {command_name} aliases must be list"
-            
+
             if 'params' in metadata:
                 assert isinstance(metadata['params'], dict), f"Command {command_name} params must be dict"
-    
+
     def test_command_functions_exist(self):
         """Test that all command functions can be imported and are callable."""
         # Map of module names to actual function names
         function_name_map = {
             'sand': 'sand',
-            'refinery': 'refinery', 
+            'refinery': 'refinery',
             'leaderboard': 'leaderboard',
             'split': 'split',
+            'fixedratecut': 'fixedratecut',
             'help': 'help',
             'reset': 'reset',
             'ledger': 'ledger',
@@ -134,21 +141,21 @@ class TestCommandResponsiveness:
             'payment': 'pay',
             'payroll': 'payroll',
         }
-        
+
         for command_name in COMMAND_METADATA.keys():
             try:
                 # Import the command module
                 command_module = __import__(f'commands.{command_name}', fromlist=[command_name])
-                
+
                 # Get the actual function name for this command
                 actual_function_name = function_name_map.get(command_name, command_name)
-                
+
                 # Get the command function
                 command_func = getattr(command_module, actual_function_name, None)
-                
+
                 assert command_func is not None, f"Command function {actual_function_name} not found in {command_name}"
                 assert callable(command_func), f"Command function {actual_function_name} is not callable"
-                
+
             except ImportError as e:
                 pytest.fail(f"Could not import command {command_name}: {e}")
             except AttributeError as e:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,9 +42,13 @@ class TestHelpers:
     
     def test_get_sand_per_melange(self):
         """Test getting sand per melange conversion rate."""
+        # Test default rate
         rate = get_sand_per_melange()
-        assert isinstance(rate, int)
-        assert rate > 0
+        assert rate == 50
+
+        # Test Landsraad bonus rate
+        rate = get_sand_per_melange(landsraad_bonus=True)
+        assert rate == 37
     
     @pytest.mark.asyncio
     async def test_send_response_interaction(self, mock_interaction):

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -18,8 +18,15 @@ def get_database():
 # Sand to melange conversion rate (implementation detail)
 SAND_PER_MELANGE = 50
 
-def get_sand_per_melange() -> int:
-    """Get the spice sand to melange conversion rate (hardcoded constant)"""
+def get_sand_per_melange(landsraad_bonus: bool = False) -> int:
+    """
+    Get the spice sand to melange conversion rate.
+    - Default rate: 50 sand per melange
+    - Landsraad bonus rate: 37 sand per melange
+    """
+    LANDSRAAD_BONUS_RATE = 37
+    if landsraad_bonus:
+        return LANDSRAAD_BONUS_RATE
     return SAND_PER_MELANGE
 
 async def send_response(interaction, content=None, embed=None, ephemeral=False, use_followup=True):

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -18,13 +18,13 @@ def get_database():
 # Sand to melange conversion rate (implementation detail)
 SAND_PER_MELANGE = 50
 
-def get_sand_per_melange(landsraad_bonus: bool = False) -> int:
+def get_sand_per_melange(landsraad_bonus: bool = False) -> float:
     """
     Get the spice sand to melange conversion rate.
     - Default rate: 50 sand per melange
     - Landsraad bonus rate: 37 sand per melange
     """
-    LANDSRAAD_BONUS_RATE = 37
+    LANDSRAAD_BONUS_RATE = 37.5
     if landsraad_bonus:
         return LANDSRAAD_BONUS_RATE
     return SAND_PER_MELANGE
@@ -94,3 +94,4 @@ async def send_response(interaction, content=None, embed=None, ephemeral=False, 
                         original_error=str(e), 
                         fallback_error=str(fallback_error))
             # Last resort - just log the error, don't raise
+


### PR DESCRIPTION
Ok, I made some changes but i'm pushing from a branch that doesn't bork your fly.io file. A summary of what was changed:

# feat: Use float division and rounding for melange calculation

This commit changes the sand-to-melange calculation to use
floating-point division and `math.ceil()` to round up the result.

**A new database migration was added to change the `sand_per_melange`
column in the `expeditions` table to `REAL` and to drop the
`leftover_sand` column from `expedition_participants`.**

_leftover_sand was stripped from the program. (may revisit later if you start getting into refining jobs in batches of 10000 sand)_

# feat: Add landsraad_bonus flag for variable conversion rate

This commit introduces a new optional boolean flag `landsraad_bonus` to the `sand`, `split`, and `fixedratecut` commands.

When `landsraad_bonus` is set to `True`, the conversion rate from sand to melange is changed from 50 to 37.5. This allows for a dynamic conversion rate based on in-game events.

# feat: implement fixedratecut command

This commit introduces a new command, `fixedratecut`, to the bot.

The `fixedratecut` command allows an administrator to distribute a fixed percentage of a total amount of "sand" to a list of tagged users. The remaining sand is allocated to the guild treasury.
