### PR TITLE
Remove leftover sand references, and make guild split greedy

### DIFF
--- a/commands/expedition.py
+++ b/commands/expedition.py
@@ -52,7 +52,7 @@ async def expedition(interaction, command_start, expedition_id: int, use_followu
             role = "🏭 Primary Harvester" if participant['is_harvester'] else "👥 Expedition Member"
             # Note: Expedition participants show sand allocation, not payment status (payments are user-level)
             participant_details.append(f"{role}: **{participant['username']}**\n"
-                                    f"   Sand: {participant['sand_amount']:,} | Melange: {participant['melange_amount']:,} | Leftover: {participant['leftover_sand']:,}")
+                                    f"   Sand: {participant['sand_amount']:,} | Melange: {participant['melange_amount']:,}")
             total_participant_sand += participant['sand_amount']
 
         # Use utility function for embed building

--- a/commands/sand.py
+++ b/commands/sand.py
@@ -57,12 +57,11 @@ async def sand(interaction, command_start, amount: int, use_followup: bool = Tru
         )
 
     # Build concise response
-    leftover_sand = amount % sand_per_melange
     description = f"🎉 **+{new_melange:,} melange**" if new_melange > 0 else f"📦 **{amount:,} sand processed**"
 
     fields = {
         "💎 Total": f"{(current_melange + new_melange):,} melange",
-        "⚙️ Converted": f"{amount:,} sand → {new_melange:,} melange" + (f" ({leftover_sand} unused)" if leftover_sand > 0 else "")
+        "⚙️ Converted": f"{amount:,} sand → {new_melange:,} melange"
     }
 
     embed = build_status_embed(

--- a/commands/split.py
+++ b/commands/split.py
@@ -74,59 +74,63 @@ async def split(interaction, command_start, total_sand: int, users: str, guild: 
             await send_response(interaction, f"❌ Total user percentages ({total_percentage}%) cannot exceed 100%.", use_followup=use_followup, ephemeral=True)
             return
 
-        # Calculate guild cut first
-        guild_sand = int(total_sand * (guild / 100))
-        remaining_sand = total_sand - guild_sand
+        # Get conversion rate first
+        sand_per_melange = get_sand_per_melange()
 
-        # Calculate user distributions
+        # Convert total sand to melange first
+        total_melange = total_sand // sand_per_melange
+        remaining_sand = total_sand % sand_per_melange  # This will go to guild as sand
+
+        # Calculate user melange distributions
         user_distributions = []
-        remaining_after_percentages = remaining_sand
+        remaining_after_percentages = total_melange
 
-        # First, allocate to percentage users
+        # First, allocate to percentage users (based on melange, not sand)
         for user_id, percentage in percentage_users:
-            user_sand = int(remaining_sand * (percentage / 100))
-            user_distributions.append((user_id, user_sand, percentage))
-            remaining_after_percentages -= user_sand
+            user_melange = int(total_melange * (percentage / 100))
+            user_distributions.append((user_id, user_melange, percentage))
+            remaining_after_percentages -= user_melange
 
-        # Then, split remaining sand equally among non-percentage users
+        # Then, split remaining melange equally among non-percentage users
         if equal_split_users:
             equal_share = remaining_after_percentages // len(equal_split_users)
-            leftover = remaining_after_percentages % len(equal_split_users)
 
-            for i, user_id in enumerate(equal_split_users):
-                # Give leftover sand to first few users
-                user_sand = equal_share + (1 if i < leftover else 0)
-                equal_percentage = (user_sand / remaining_sand) * 100 if remaining_sand > 0 else 0
-                user_distributions.append((user_id, user_sand, equal_percentage))
+            for user_id in equal_split_users:
+                user_melange = equal_share
+                equal_percentage = (user_melange / total_melange) * 100 if total_melange > 0 else 0
+                user_distributions.append((user_id, user_melange, equal_percentage))
 
         # Remove duplicates and validate we have users
         unique_distributions = {}
-        for user_id, sand, percentage in user_distributions:
+        for user_id, melange, percentage in user_distributions:
             if user_id in unique_distributions:
                 # Combine if user mentioned multiple times
-                existing_sand, existing_pct = unique_distributions[user_id]
-                unique_distributions[user_id] = (existing_sand + sand, existing_pct + percentage)
+                existing_melange, existing_pct = unique_distributions[user_id]
+                unique_distributions[user_id] = (existing_melange + melange, existing_pct + percentage)
             else:
-                unique_distributions[user_id] = (sand, percentage)
+                unique_distributions[user_id] = (melange, percentage)
 
         if not unique_distributions:
             await send_response(interaction, "❌ No valid users found to split with.", use_followup=use_followup, ephemeral=True)
             return
 
-        # Get conversion rate
-        sand_per_melange = get_sand_per_melange()
+        # Calculate remaining melange that goes to guild
+        total_user_melange = sum(melange for melange, _ in unique_distributions.values())
+        guild_melange = total_melange - total_user_melange
+        guild_sand = remaining_sand  # Any leftover sand also goes to guild
 
         # Ensure the initiator exists in the users table
         from utils.database_utils import validate_user_exists
         await validate_user_exists(get_database(), str(interaction.user.id), interaction.user.display_name)
 
-        # Create expedition record with guild cut
+        # Create expedition record (guild percentage is now calculated based on actual distribution)
+        actual_guild_percentage = ((guild_melange + guild_sand) / total_sand) * 100 if total_sand > 0 else 0
         expedition_id = await get_database().create_expedition(
             str(interaction.user.id),
             interaction.user.display_name,
             total_sand,
             sand_per_melange=sand_per_melange,
-            guild_cut_percentage=guild
+            guild_cut_percentage=actual_guild_percentage
         )
 
         if not expedition_id:
@@ -134,15 +138,13 @@ async def split(interaction, command_start, total_sand: int, users: str, guild: 
             return
 
         # Add guild cut to treasury if > 0
-        if guild_sand > 0:
-            guild_melange = guild_sand // sand_per_melange
+        if guild_melange > 0 or guild_sand > 0:
             await get_database().update_guild_treasury(guild_sand, guild_melange)
 
         # Process all participants
         participant_details = []
-        total_user_melange = 0
 
-        for user_id, (user_sand, user_percentage) in unique_distributions.items():
+        for user_id, (user_melange, user_percentage) in unique_distributions.items():
             try:
                 # Try to get user from guild first, then client
                 try:
@@ -160,42 +162,36 @@ async def split(interaction, command_start, total_sand: int, users: str, guild: 
                 logger.error(f"Invalid user ID format: {user_id}, error: {e}")
                 display_name = f"User_{user_id}"
 
-                # Ensure user exists in database
-                await validate_user_exists(get_database(), user_id, display_name)
+            # Ensure user exists in database
+            await validate_user_exists(get_database(), user_id, display_name)
 
-                # Calculate melange and leftover sand
-                participant_melange = user_sand // sand_per_melange
-                participant_leftover = user_sand % sand_per_melange
-                total_user_melange += participant_melange
+            # Calculate equivalent sand for this user's melange (for deposit tracking)
+            user_sand = user_melange * sand_per_melange
 
-                # Add expedition participant
-                await get_database().add_expedition_participant(
-                    expedition_id, user_id, display_name, user_sand,
-                    participant_melange, participant_leftover, is_harvester=False
-                )
+            # Add expedition participant
+            await get_database().add_expedition_participant(
+                expedition_id, user_id, display_name, user_sand,
+                user_melange, is_harvester=False
+            )
 
-                # Add deposit record
-                await get_database().add_deposit(user_id, display_name, user_sand, expedition_id=expedition_id)
+            # Add deposit record (using equivalent sand amount)
+            await get_database().add_deposit(user_id, display_name, user_sand, expedition_id=expedition_id)
 
-                # Update user's melange total if they earned melange
-                if participant_melange > 0:
-                    await get_database().update_user_melange(user_id, participant_melange)
+            # Update user's melange total if they earned melange
+            if user_melange > 0:
+                await get_database().update_user_melange(user_id, user_melange)
 
                 # Format for display
                 percentage_text = f" ({user_percentage:.1f}%)" if user_percentage > 0 else ""
-                participant_details.append(f"**{display_name}**: {user_sand:,} sand ({participant_melange:,} melange){percentage_text}")
-
-            except Exception as participant_error:
-                logger.error(f"Error processing participant {user_id}: {participant_error}")
-                participant_details.append(f"**User_{user_id}**: {user_sand:,} sand (error processing)")
+                participant_details.append(f"**{display_name}**: {user_melange:,} melange{percentage_text}")
 
         # Build response embed
         from utils.embed_utils import build_status_embed
 
         fields = {
             "👥 Participants": "\n".join(participant_details),
-            "🏛️ Guild Cut": f"**{guild}%** = {guild_sand:,} sand → **{guild_sand // sand_per_melange:,} melange**",
-            "📊 Summary": f"**Total:** {total_sand:,} | **Users:** {remaining_sand:,} sand → **{total_user_melange:,} melange**"
+            "🏛️ Guild Cut": f"**{actual_guild_percentage:.1f}%** = {guild_sand:,} sand + **{guild_melange:,} melange**",
+            "📊 Summary": f"**Total:** {total_sand:,} sand → **{total_melange:,} melange** | **Users:** **{total_user_melange:,} melange** | **Guild:** **{guild_melange:,} melange**"
         }
 
         embed = build_status_embed(
@@ -211,7 +207,8 @@ async def split(interaction, command_start, total_sand: int, users: str, guild: 
 
         # Log the expedition creation
         logger.info(f"Expedition {expedition_id} created by {interaction.user.display_name} ({interaction.user.id})",
-                   total_sand=total_sand, guild_cut=guild_sand, participants=len(unique_distributions))
+                   total_sand=total_sand, total_melange=total_melange, guild_melange=guild_melange,
+                   guild_sand=guild_sand, participants=len(unique_distributions))
 
     except Exception as error:
         logger.error(f"Error in split command: {error}")

--- a/database.py
+++ b/database.py
@@ -11,7 +11,7 @@ class Database:
         self.database_url = database_url or os.getenv('DATABASE_URL')
         if not self.database_url:
             raise ValueError("DATABASE_URL environment variable is required")
-        
+
         # Connection pool settings for better reliability
         self.max_retries = 3
         self.retry_delay = 1.0  # Base delay in seconds
@@ -21,7 +21,7 @@ class Database:
         """Context manager for database connections with retry logic"""
         conn = None
         last_error = None
-        
+
         for attempt in range(self.max_retries):
             start_time = time.time()
             try:
@@ -35,7 +35,7 @@ class Database:
                         'application_name': 'spice_tracker_bot'
                     }
                 )
-                
+
                 connection_time = time.time() - start_time
                 logger.database_operation(
                     operation="connection_established",
@@ -44,7 +44,7 @@ class Database:
                     attempt=attempt + 1,
                     connection_time=f"{connection_time:.3f}s"
                 )
-                
+
                 # Successfully connected, yield and then clean up
                 try:
                     yield conn
@@ -56,7 +56,7 @@ class Database:
                             await asyncio.wait_for(conn.close(), timeout=5.0)
                         except (asyncio.TimeoutError, Exception) as close_error:
                             logger.warning(f"Connection close timeout/failure: {close_error}")
-                            
+
             except Exception as e:
                 last_error = e
                 connection_time = time.time() - start_time
@@ -68,7 +68,7 @@ class Database:
                     connection_time=f"{connection_time:.3f}s",
                     error=str(e)
                 )
-                
+
                 # Close failed connection if it exists
                 if conn and not conn.is_closed():
                     try:
@@ -76,7 +76,7 @@ class Database:
                     except Exception:
                         pass  # Ignore close errors on failed connections
                     conn = None
-                
+
                 if attempt < self.max_retries - 1:
                     # Wait before retrying
                     await asyncio.sleep(self.retry_delay * (attempt + 1))
@@ -105,11 +105,11 @@ class Database:
             async with self._get_connection() as conn:
                 # Simple connectivity test
                 await conn.fetchval('SELECT 1')
-                
+
             init_time = time.time() - start_time
             await self._log_operation("connectivity_check", "database", start_time, success=True, init_time=f"{init_time:.3f}s")
             print(f'✅ Database connected in {init_time:.3f}s')
-            
+
         except Exception as e:
             init_time = time.time() - start_time
             await self._log_operation("connectivity_check", "database", start_time, success=False, init_time=f"{init_time:.3f}s", error=str(e))
@@ -128,7 +128,7 @@ class Database:
                 if row:
                     result = {
                         'user_id': row['user_id'],
-                        'username': row['username'], 
+                        'username': row['username'],
                         'total_melange': row['total_melange'],
                         'paid_melange': row['paid_melange'],
                         'created_at': row.get('created_at', datetime.now()),
@@ -167,17 +167,17 @@ class Database:
             try:
                 # Ensure user exists
                 await self.upsert_user(user_id, username)
-                
+
                 # Add deposit record (for history/audit purposes only)
                 await conn.execute('''
                     INSERT INTO deposits (user_id, username, sand_amount, type, expedition_id, created_at)
                     VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
                 ''', user_id, username, sand_amount, deposit_type, expedition_id)
-                
-                await self._log_operation("insert", "deposits", start_time, success=True, 
+
+                await self._log_operation("insert", "deposits", start_time, success=True,
                                         user_id=user_id, sand_amount=sand_amount, deposit_type=deposit_type, expedition_id=expedition_id)
             except Exception as e:
-                await self._log_operation("insert", "deposits", start_time, success=False, 
+                await self._log_operation("insert", "deposits", start_time, success=False,
                                         user_id=user_id, sand_amount=sand_amount, deposit_type=deposit_type, expedition_id=expedition_id, error=str(e))
                 raise e
 
@@ -188,13 +188,13 @@ class Database:
             try:
                 query = '''
                     SELECT id, user_id, username, sand_amount, type, expedition_id, created_at
-                    FROM deposits 
+                    FROM deposits
                     WHERE user_id = $1
                     ORDER BY created_at DESC
                 '''
-                
+
                 rows = await conn.fetch(query, user_id)
-                
+
                 deposits = []
                 for row in rows:
                     deposits.append({
@@ -206,12 +206,12 @@ class Database:
                         'expedition_id': row['expedition_id'],
                         'created_at': row.get('created_at', datetime.now())
                     })
-                
-                await self._log_operation("select", "deposits", start_time, success=True, 
+
+                await self._log_operation("select", "deposits", start_time, success=True,
                                         user_id=user_id, result_count=len(deposits))
                 return deposits
             except Exception as e:
-                await self._log_operation("select", "deposits", start_time, success=False, 
+                await self._log_operation("select", "deposits", start_time, success=False,
                                         user_id=user_id, error=str(e))
                 raise e
 
@@ -225,13 +225,13 @@ class Database:
                     VALUES ($1, $2, $3, $4, $5)
                     RETURNING id
                 ''', initiator_id, initiator_username, total_sand, sand_per_melange, guild_cut_percentage)
-                
+
                 expedition_id = row['id'] if row else None
-                await self._log_operation("insert", "expeditions", start_time, success=True, 
+                await self._log_operation("insert", "expeditions", start_time, success=True,
                                         initiator_id=initiator_id, total_sand=total_sand, expedition_id=expedition_id, guild_cut_percentage=guild_cut_percentage)
                 return expedition_id
             except Exception as e:
-                await self._log_operation("insert", "expeditions", start_time, success=False, 
+                await self._log_operation("insert", "expeditions", start_time, success=False,
                                         initiator_id=initiator_id, total_sand=total_sand, error=str(e))
                 raise e
 
@@ -246,7 +246,7 @@ class Database:
                     ORDER BY id DESC
                     LIMIT 1
                 ''')
-                
+
                 if row:
                     treasury = {
                         'total_sand': row['total_sand'],
@@ -261,7 +261,7 @@ class Database:
                         VALUES ($1, $2)
                     ''', 0, 0)
                     treasury = {'total_sand': 0, 'total_melange': 0, 'created_at': None, 'last_updated': None}
-                
+
                 await self._log_operation("select", "guild_treasury", start_time, success=True)
                 return treasury
             except Exception as e:
@@ -276,24 +276,24 @@ class Database:
                 async with conn.transaction():
                     # First try to update existing record
                     result = await conn.execute('''
-                        UPDATE guild_treasury 
+                        UPDATE guild_treasury
                         SET total_sand = total_sand + $1,
                             total_melange = total_melange + $2,
                             last_updated = CURRENT_TIMESTAMP
                     ''', sand_amount, melange_amount)
-                    
+
                     # If no rows were updated, insert initial record
                     if result == 'UPDATE 0':
                         await conn.execute('''
                             INSERT INTO guild_treasury (total_sand, total_melange)
                             VALUES ($1, $2)
                         ''', sand_amount, melange_amount)
-                
-                await self._log_operation("update", "guild_treasury", start_time, success=True, 
+
+                await self._log_operation("update", "guild_treasury", start_time, success=True,
                                         sand_amount=sand_amount, melange_amount=melange_amount)
                 return True
             except Exception as e:
-                await self._log_operation("update", "guild_treasury", start_time, success=False, 
+                await self._log_operation("update", "guild_treasury", start_time, success=False,
                                         sand_amount=sand_amount, melange_amount=melange_amount, error=str(e))
                 raise e
 
@@ -306,51 +306,51 @@ class Database:
                 treasury = await self.get_guild_treasury()
                 if treasury['total_sand'] < sand_amount:
                     raise ValueError(f"Insufficient guild treasury funds. Available: {treasury['total_sand']}, Requested: {sand_amount}")
-                
+
                 # Start transaction
                 async with conn.transaction():
                     # Remove sand from guild treasury
                     await conn.execute('''
-                        UPDATE guild_treasury 
+                        UPDATE guild_treasury
                         SET total_sand = total_sand - $1,
                             last_updated = CURRENT_TIMESTAMP
                         WHERE id = (SELECT MAX(id) FROM guild_treasury)
                     ''', sand_amount)
-                    
+
                     # Add sand to user as deposit
                     await conn.execute('''
                         INSERT INTO deposits (user_id, username, sand_amount, type, paid, created_at, paid_at)
                         VALUES ($1, $2, $3, 'guild_withdrawal', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                     ''', target_user_id, target_username, sand_amount)
-                    
+
                     # Record transaction
                     await conn.execute('''
                         INSERT INTO guild_transactions (transaction_type, sand_amount, admin_user_id, admin_username, target_user_id, target_username, description)
                         VALUES ('withdrawal', $1, $2, $3, $4, $5, $6)
                     ''', sand_amount, admin_user_id, admin_username, target_user_id, target_username, f"Guild withdrawal to {target_username}")
-                
-                await self._log_operation("update", "guild_treasury", start_time, success=True, 
+
+                await self._log_operation("update", "guild_treasury", start_time, success=True,
                                         operation="withdrawal", sand_amount=sand_amount, target_user_id=target_user_id)
                 return True
             except Exception as e:
-                await self._log_operation("update", "guild_treasury", start_time, success=False, 
+                await self._log_operation("update", "guild_treasury", start_time, success=False,
                                         operation="withdrawal", sand_amount=sand_amount, target_user_id=target_user_id, error=str(e))
                 raise e
 
-    async def add_expedition_participant(self, expedition_id, user_id, username, sand_amount, melange_amount, leftover_sand, is_harvester=False):
+    async def add_expedition_participant(self, expedition_id, user_id, username, sand_amount, melange_amount, is_harvester=False):
         """Add a participant to an expedition"""
         start_time = time.time()
         async with self._get_connection() as conn:
             try:
                 await conn.execute('''
-                    INSERT INTO expedition_participants (expedition_id, user_id, username, sand_amount, melange_amount, leftover_sand, is_harvester)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7)
-                ''', expedition_id, user_id, username, sand_amount, melange_amount, leftover_sand, is_harvester)
-                
-                await self._log_operation("insert", "expedition_participants", start_time, success=True, 
+                    INSERT INTO expedition_participants (expedition_id, user_id, username, sand_amount, melange_amount, is_harvester)
+                    VALUES ($1, $2, $3, $4, $5, $6)
+                ''', expedition_id, user_id, username, sand_amount, melange_amount, is_harvester)
+
+                await self._log_operation("insert", "expedition_participants", start_time, success=True,
                                         expedition_id=expedition_id, user_id=user_id, sand_amount=sand_amount, is_harvester=is_harvester)
             except Exception as e:
-                await self._log_operation("insert", "expedition_participants", start_time, success=False, 
+                await self._log_operation("insert", "expedition_participants", start_time, success=False,
                                         expedition_id=expedition_id, user_id=user_id, sand_amount=sand_amount, is_harvester=is_harvester, error=str(e))
                 raise e
 
@@ -361,17 +361,17 @@ class Database:
             try:
                 # Ensure user exists
                 await self.upsert_user(user_id, username)
-                
+
                 # Add deposit record with expedition type
                 await conn.execute('''
                     INSERT INTO deposits (user_id, username, sand_amount, type, expedition_id, created_at)
                     VALUES ($1, $2, $3, 'expedition', $4, CURRENT_TIMESTAMP)
                 ''', user_id, username, sand_amount, expedition_id)
-                
-                await self._log_operation("insert", "deposits", start_time, success=True, 
+
+                await self._log_operation("insert", "deposits", start_time, success=True,
                                         user_id=user_id, sand_amount=sand_amount, expedition_id=expedition_id, type="expedition")
             except Exception as e:
-                await self._log_operation("insert", "deposits", start_time, success=False, 
+                await self._log_operation("insert", "deposits", start_time, success=False,
                                         user_id=user_id, sand_amount=sand_amount, expedition_id=expedition_id, type="expedition", error=str(e))
                 raise e
 
@@ -382,22 +382,22 @@ class Database:
             try:
                 # Get expedition details first
                 expedition_row = await conn.fetchrow('''
-                    SELECT initiator_id, initiator_username, total_sand, guild_cut_percentage, 
+                    SELECT initiator_id, initiator_username, total_sand, guild_cut_percentage,
                            sand_per_melange, created_at
-                    FROM expeditions 
+                    FROM expeditions
                     WHERE id = $1
                 ''', expedition_id)
-                
+
                 if not expedition_row:
                     return None
-                
+
                 # Get participants
                 rows = await conn.fetch('''
-                    SELECT * FROM expedition_participants 
+                    SELECT * FROM expedition_participants
                     WHERE expedition_id = $1
                     ORDER BY is_harvester DESC, username ASC
                 ''', expedition_id)
-                
+
                 participants = []
                 for row in rows:
                     participants.append({
@@ -407,10 +407,9 @@ class Database:
                         'username': row['username'],
                         'sand_amount': row['sand_amount'],
                         'melange_amount': row['melange_amount'],
-                        'leftover_sand': row['leftover_sand'],
                         'is_harvester': bool(row['is_harvester'])
                     })
-                
+
                 # Combine expedition details with participants
                 result = {
                     'expedition': {
@@ -424,12 +423,12 @@ class Database:
                     },
                     'participants': participants
                 }
-                
-                await self._log_operation("select", "expedition_participants", start_time, success=True, 
+
+                await self._log_operation("select", "expedition_participants", start_time, success=True,
                                         expedition_id=expedition_id, result_count=len(participants))
                 return result
             except Exception as e:
-                await self._log_operation("select", "expedition_participants", start_time, success=False, 
+                await self._log_operation("select", "expedition_participants", start_time, success=False,
                                         expedition_id=expedition_id, error=str(e))
                 raise e
 
@@ -445,14 +444,14 @@ class Database:
                     WHERE d.user_id = $1 AND d.type = 'expedition'
                 '''
                 params = [user_id]
-                
+
                 if not include_paid:
                     query += ' AND d.paid = FALSE'
-                
+
                 query += ' ORDER BY d.created_at DESC'
-                
+
                 rows = await conn.fetch(query, *params)
-                
+
                 deposits = []
                 for row in rows:
                     deposits.append({
@@ -468,12 +467,12 @@ class Database:
                         'initiator_username': row.get('initiator_username'),
                         'expedition_total': row.get('expedition_total')
                     })
-                
-                await self._log_operation("select", "deposits_join_expeditions", start_time, success=True, 
+
+                await self._log_operation("select", "deposits_join_expeditions", start_time, success=True,
                                         user_id=user_id, include_paid=include_paid, result_count=len(deposits))
                 return deposits
             except Exception as e:
-                await self._log_operation("select", "deposits_join_expeditions", start_time, success=False, 
+                await self._log_operation("select", "deposits_join_expeditions", start_time, success=False,
                                         user_id=user_id, include_paid=include_paid, error=str(e))
                 raise e
 
@@ -486,16 +485,16 @@ class Database:
             try:
                 row = await conn.fetchrow('''
                     SELECT COALESCE(SUM(sand_amount), 0) as total_sand
-                    FROM deposits 
+                    FROM deposits
                     WHERE user_id = $1 AND paid = TRUE
                 ''', user_id)
-                
+
                 total_sand = row['total_sand'] if row else 0
-                await self._log_operation("select_sum", "deposits", start_time, success=True, 
+                await self._log_operation("select_sum", "deposits", start_time, success=True,
                                         user_id=user_id, total_sand=total_sand, paid=True)
                 return total_sand
             except Exception as e:
-                await self._log_operation("select_sum", "deposits", start_time, success=False, 
+                await self._log_operation("select_sum", "deposits", start_time, success=False,
                                         user_id=user_id, paid=True, error=str(e))
                 raise e
 
@@ -507,23 +506,23 @@ class Database:
                 async with conn.transaction():
                     # Update user's paid_melange
                     await conn.execute('''
-                        UPDATE users 
+                        UPDATE users
                         SET paid_melange = paid_melange + $1,
                             last_updated = CURRENT_TIMESTAMP
                         WHERE user_id = $2
                     ''', melange_amount, user_id)
-                    
+
                     # Record the payment
                     await conn.execute('''
                         INSERT INTO melange_payments (user_id, username, melange_amount, admin_user_id, admin_username, description)
                         VALUES ($1, $2, $3, $4, $5, $6)
                     ''', user_id, username, melange_amount, admin_user_id, admin_username, f"Melange payment to {username}")
-                
-                await self._log_operation("update", "melange_payments", start_time, success=True, 
+
+                await self._log_operation("update", "melange_payments", start_time, success=True,
                                         user_id=user_id, melange_amount=melange_amount, admin_user_id=admin_user_id)
                 return melange_amount
             except Exception as e:
-                await self._log_operation("update", "melange_payments", start_time, success=False, 
+                await self._log_operation("update", "melange_payments", start_time, success=False,
                                         user_id=user_id, melange_amount=melange_amount, admin_user_id=admin_user_id, error=str(e))
                 raise e
 
@@ -536,39 +535,39 @@ class Database:
                 users_with_pending = await conn.fetch('''
                     SELECT user_id, username, total_melange, paid_melange,
                            (total_melange - paid_melange) as pending_melange
-                    FROM users 
+                    FROM users
                     WHERE total_melange > paid_melange
                 ''')
-                
+
                 total_paid = 0
                 users_paid = 0
-                
+
                 async with conn.transaction():
                     for user in users_with_pending:
                         pending = user['pending_melange']
                         if pending > 0:
                             # Update user's paid_melange
                             await conn.execute('''
-                                UPDATE users 
+                                UPDATE users
                                 SET paid_melange = total_melange,
                                     last_updated = CURRENT_TIMESTAMP
                                 WHERE user_id = $1
                             ''', user['user_id'])
-                            
+
                             # Record the payment
                             await conn.execute('''
                                 INSERT INTO melange_payments (user_id, username, melange_amount, admin_user_id, admin_username, description)
                                 VALUES ($1, $2, $3, $4, $5, $6)
                             ''', user['user_id'], user['username'], pending, admin_user_id, admin_username, f"Bulk melange payment to {user['username']}")
-                            
+
                             total_paid += pending
                             users_paid += 1
-                
-                await self._log_operation("update", "melange_payments", start_time, success=True, 
+
+                await self._log_operation("update", "melange_payments", start_time, success=True,
                                         total_paid=total_paid, users_paid=users_paid, admin_user_id=admin_user_id)
                 return {"total_paid": total_paid, "users_paid": users_paid}
             except Exception as e:
-                await self._log_operation("update", "melange_payments", start_time, success=False, 
+                await self._log_operation("update", "melange_payments", start_time, success=False,
                                         admin_user_id=admin_user_id, error=str(e))
                 raise e
 
@@ -578,12 +577,12 @@ class Database:
         async with self._get_connection() as conn:
             try:
                 row = await conn.fetchrow('''
-                    SELECT total_melange, paid_melange, 
+                    SELECT total_melange, paid_melange,
                            (total_melange - paid_melange) as pending_melange
-                    FROM users 
+                    FROM users
                     WHERE user_id = $1
                 ''', user_id)
-                
+
                 if row:
                     result = {
                         'total_melange': row['total_melange'],
@@ -592,12 +591,12 @@ class Database:
                     }
                 else:
                     result = {'total_melange': 0, 'paid_melange': 0, 'pending_melange': 0}
-                
-                await self._log_operation("select", "users", start_time, success=True, 
+
+                await self._log_operation("select", "users", start_time, success=True,
                                         user_id=user_id, pending_melange=result['pending_melange'])
                 return result
             except Exception as e:
-                await self._log_operation("select", "users", start_time, success=False, 
+                await self._log_operation("select", "users", start_time, success=False,
                                         user_id=user_id, error=str(e))
                 raise e
 
@@ -613,7 +612,7 @@ class Database:
                     WHERE u.total_melange > u.paid_melange
                     ORDER BY pending_melange DESC, u.username
                 ''')
-                
+
                 users = []
                 for row in rows:
                     users.append({
@@ -623,8 +622,8 @@ class Database:
                         'paid_melange': row['paid_melange'],
                         'pending_melange': row['pending_melange']
                     })
-                
-                await self._log_operation("select", "users", start_time, success=True, 
+
+                await self._log_operation("select", "users", start_time, success=True,
                                         result_count=len(users))
                 return users
             except Exception as e:
@@ -638,10 +637,10 @@ class Database:
             try:
                 cutoff_date = datetime.now() - timedelta(days=days)
                 result = await conn.execute('''
-                    DELETE FROM deposits 
+                    DELETE FROM deposits
                     WHERE created_at < $1 AND paid = TRUE
                 ''', cutoff_date)
-                
+
                 # Parse the result string to get the count of deleted rows
                 if result:
                     try:
@@ -652,12 +651,12 @@ class Database:
                         deleted_count = 0
                 else:
                     deleted_count = 0
-                
-                await self._log_operation("delete", "deposits", start_time, success=True, 
+
+                await self._log_operation("delete", "deposits", start_time, success=True,
                                         days=days, deleted_count=deleted_count)
                 return deleted_count
             except Exception as e:
-                await self._log_operation("delete", "deposits", start_time, success=False, 
+                await self._log_operation("delete", "deposits", start_time, success=False,
                                         days=days, error=str(e))
                 raise e
 
@@ -667,16 +666,16 @@ class Database:
         async with self._get_connection() as conn:
             try:
                 await conn.execute('''
-                    UPDATE users 
+                    UPDATE users
                     SET total_melange = total_melange + $1,
                         last_updated = CURRENT_TIMESTAMP
                     WHERE user_id = $2
                 ''', melange_amount, user_id)
-                
-                await self._log_operation("update", "users", start_time, success=True, 
+
+                await self._log_operation("update", "users", start_time, success=True,
                                         user_id=user_id, melange_amount=melange_amount)
             except Exception as e:
-                await self._log_operation("update", "users", start_time, success=False, 
+                await self._log_operation("update", "users", start_time, success=False,
                                         user_id=user_id, melange_amount=melange_amount, error=str(e))
                 raise e
 
@@ -689,17 +688,17 @@ class Database:
             try:
                 rows = await conn.fetch('''
                     SELECT username, total_melange
-                    FROM users 
+                    FROM users
                     ORDER BY total_melange DESC, username ASC
                     LIMIT $1
                 ''', limit)
-                
+
                 result = [dict(row) for row in rows]
-                await self._log_operation("select_join", "users_deposits", start_time, success=True, 
+                await self._log_operation("select_join", "users_deposits", start_time, success=True,
                                         limit=limit, result_count=len(result))
                 return result
             except Exception as e:
-                await self._log_operation("select_join", "users_deposits", start_time, success=False, 
+                await self._log_operation("select_join", "users_deposits", start_time, success=False,
                                         limit=limit, error=str(e))
                 raise e
 
@@ -712,13 +711,13 @@ class Database:
                     'SELECT value FROM settings WHERE key = $1',
                     key
                 )
-                
+
                 value = row['value'] if row else None
-                await self._log_operation("select", "settings", start_time, success=True, 
+                await self._log_operation("select", "settings", start_time, success=True,
                                         key=key, found=value is not None)
                 return value
             except Exception as e:
-                await self._log_operation("select", "settings", start_time, success=False, 
+                await self._log_operation("select", "settings", start_time, success=False,
                                         key=key, error=str(e))
                 raise e
 
@@ -731,11 +730,11 @@ class Database:
                     'INSERT INTO settings (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value',
                     key, value
                 )
-                
-                await self._log_operation("upsert", "settings", start_time, success=True, 
+
+                await self._log_operation("upsert", "settings", start_time, success=True,
                                         key=key, value=value)
             except Exception as e:
-                await self._log_operation("upsert", "settings", start_time, success=False, 
+                await self._log_operation("upsert", "settings", start_time, success=False,
                                         key=key, value=value, error=str(e))
                 raise e
 
@@ -748,19 +747,19 @@ class Database:
                 # 1. Leaf tables first (no foreign key dependencies)
                 result1 = await conn.execute('DELETE FROM melange_payments')
                 result2 = await conn.execute('DELETE FROM guild_transactions')
-                
+
                 # 2. Tables that reference both expeditions and users
                 result3 = await conn.execute('DELETE FROM expedition_participants')
-                
+
                 # 3. Tables that reference users or expeditions
                 result4 = await conn.execute('DELETE FROM deposits')
-                
+
                 # 4. Expeditions table (references users)
                 result5 = await conn.execute('DELETE FROM expeditions')
-                
+
                 # 5. Users table last (root table)
                 result6 = await conn.execute('DELETE FROM users')
-                
+
                 # Parse the result strings to get the count of deleted rows
                 def parse_delete_result(result):
                     if result:
@@ -771,16 +770,16 @@ class Database:
                         except (ValueError, IndexError):
                             return 0
                     return 0
-                
-                deleted_count = (parse_delete_result(result1) + parse_delete_result(result2) + 
-                               parse_delete_result(result3) + parse_delete_result(result4) + 
+
+                deleted_count = (parse_delete_result(result1) + parse_delete_result(result2) +
+                               parse_delete_result(result3) + parse_delete_result(result4) +
                                parse_delete_result(result5) + parse_delete_result(result6))
-                
-                await self._log_operation("delete_all", "all_tables", start_time, success=True, 
+
+                await self._log_operation("delete_all", "all_tables", start_time, success=True,
                                         deleted_count=deleted_count)
                 return deleted_count
             except Exception as e:
-                await self._log_operation("delete_all", "all_tables", start_time, success=False, 
+                await self._log_operation("delete_all", "all_tables", start_time, success=False,
                                         error=str(e))
                 raise e
 
@@ -796,7 +795,7 @@ class Database:
                     WHERE d.paid = FALSE
                     ORDER BY d.created_at ASC
                 ''')
-                
+
                 deposits = []
                 for row in rows:
                     deposits.append({
@@ -811,11 +810,11 @@ class Database:
                         'paid_at': row.get('paid_at'),
                         'total_melange': row.get('total_melange', 0)
                     })
-                
-                await self._log_operation("select_join", "deposits_users", start_time, success=True, 
+
+                await self._log_operation("select_join", "deposits_users", start_time, success=True,
                                         result_count=len(deposits))
                 return deposits
             except Exception as e:
-                await self._log_operation("select_join", "deposits_users", start_time, success=False, 
+                await self._log_operation("select_join", "deposits_users", start_time, success=False,
                                         error=str(e))
                 raise e

--- a/supabase/migrations/20241201000000_initial_schema.sql
+++ b/supabase/migrations/20241201000000_initial_schema.sql
@@ -119,7 +119,7 @@ CREATE INDEX idx_melange_payments_created_at ON melange_payments (created_at);
 INSERT INTO settings (key, value) VALUES ('sand_per_melange', '50');
 
 -- Initial guild treasury record
-INSERT INTO guild_treasury (total_sand, total_melange) 
+INSERT INTO guild_treasury (total_sand, total_melange)
 VALUES (0, 0);
 
 -- Useful views for common queries
@@ -128,7 +128,7 @@ VALUES (0, 0);
 
 -- Leaderboard view
 CREATE VIEW leaderboard AS
-SELECT 
+SELECT
     u.user_id,
     u.username,
     u.total_melange,
@@ -144,7 +144,7 @@ ORDER BY u.total_melange DESC, pending_melange DESC;
 
 -- Expedition summary view
 CREATE VIEW expedition_summary AS
-SELECT 
+SELECT
     e.id,
     e.initiator_username,
     e.total_sand,

--- a/supabase/migrations/20241201000001_remove_leftover_sand.sql
+++ b/supabase/migrations/20241201000001_remove_leftover_sand.sql
@@ -1,0 +1,5 @@
+-- Remove leftover_sand column from expedition_participants table
+-- This migration removes the leftover_sand tracking functionality
+
+-- Drop the leftover_sand column from expedition_participants table
+ALTER TABLE expedition_participants DROP COLUMN IF EXISTS leftover_sand;


### PR DESCRIPTION
`/split user1 20 user2 20` will now allocate 60% to the guild, even if a lower cut was specified

"Leftover sand" was removed entirely as it's useless