### PR TITLE
Fly actions-based deploy allows collab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,3 +196,27 @@ jobs:
         echo "🔒 Security Checks: ✅ PASSED"
         echo "📦 Dependency Checks: ✅ PASSED"
         echo "🔍 All checks completed - ready for manual deployment"
+
+  deploy:
+    name: Deploy to Fly.io
+    runs-on: ubuntu-latest
+    needs: [test, security, dependency-check]
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.test.result == 'success' &&
+      needs.security.result == 'success' &&
+      needs.dependency-check.result == 'success'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Flyctl
+      uses: superfly/flyctl-actions/setup-flyctl@v1
+
+    - name: Deploy
+      env:
+        FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        FLY_APP: ${{ secrets.FLY_APP }}
+      run: flyctl deploy --app "${FLY_APP}" --remote-only

--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,8 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-#app = 'spice-tracker-bot-wlpasq'
+# Do not set this. Pass it as FLY_APP
+#app = ''
 primary_region = 'iad'
 
 [build]


### PR DESCRIPTION
Set `FLY_API_TOKEN` and `FLY_APP` in repo actions secrets. This will deploy to Fly on `main` push after CI checks pass.

Disable "deploy on push" in Fly otherwise deployments will be duplicated.