### PR TITLE
fix: Enforce asyncpg driver for PostgreSQL connections

### DIFF
--- a/database_orm.py
+++ b/database_orm.py
@@ -201,6 +201,12 @@ class Database:
         if not self.database_url:
             raise ValueError("DATABASE_URL environment variable is required")
 
+        # Ensure the DATABASE_URL uses the asyncpg driver for PostgreSQL connections.
+        if self.database_url.startswith("postgresql://"):
+            self.database_url = self.database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+        elif self.database_url.startswith("postgresql+psycopg2://"):
+            self.database_url = self.database_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://", 1)
+
         # Create async engine
         self.engine = create_async_engine(
             self.database_url,


### PR DESCRIPTION
The application was failing to connect to the database with the error "The asyncio extension requires an async driver to be used" because the `DATABASE_URL` was configured with `postgresql://`, which defaults to the synchronous `psycopg2` driver.

This commit modifies the `Database` class to programmatically ensure that the `asyncpg` driver is used for all PostgreSQL connections. It inspects the database URL and replaces `postgresql://` or `postgresql+psycopg2://` with `postgresql+asyncpg://` before creating the async engine. This makes the database connection robust to misconfiguration in the environment.