### PR TITLE
Feature fix/guild withdraw melange + a /payroll bugfix + a lil bandaid

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -238,10 +238,10 @@ def register_commands():
         await treasury(interaction)
 
     # Guild Withdraw command
-    @bot.tree.command(name=cmd_name("guild_withdraw"), description="Withdraw sand from guild treasury to give to a user (Admin only)")
+    @bot.tree.command(name=cmd_name("guild_withdraw"), description="Withdraw melange from guild treasury to give to a user (Admin only)")
     @app_commands.describe(
-        user="User to give sand to",
-        amount="Amount of sand to withdraw from guild treasury"
+        user="The user whose ledger to credit melange",
+        amount="Amount of melange to credit from guild treasury"
     )
     async def guild_withdraw_cmd(interaction: discord.Interaction, user: discord.Member, amount: int):  # noqa: F841
         await guild_withdraw(interaction, user, amount)

--- a/commands/guild_withdraw.py
+++ b/commands/guild_withdraw.py
@@ -1,14 +1,14 @@
 """
-Guild Withdraw command for transferring sand from guild treasury to users (Admin only).
+Guild Withdraw command for transferring melange from guild treasury to users (Admin only).
 """
 
 # Command metadata
 COMMAND_METADATA = {
-    'aliases': [],  # ['withdraw'] - removed for simplicity
-    'description': "Withdraw sand from guild treasury to give to a user (Admin/Officer only)",
+    'aliases': [],  # ['gwithdraw']
+    'description': "Withdraw melange from guild treasury to give to a user (Admin/Officer only)",
     'params': {
-        'user': "User to give sand to",
-        'amount': "Amount of sand to withdraw from guild treasury"
+        'user': "User to give melange to",
+        'amount': "Amount of melange to withdraw from guild treasury"
     },
     'permission_level': 'admin_or_officer'
 }
@@ -25,12 +25,12 @@ from utils.logger import logger
 
 @admin_command('guild_withdraw')
 async def guild_withdraw(interaction, command_start, user: discord.Member, amount: int, use_followup: bool = True):
-    """Withdraw sand from guild treasury and give to a user (Admin only)"""
+    """Withdraw melange from guild treasury and give to a user (Admin only)"""
 
     try:
         # Validate amount
         if amount < 1:
-            await send_response(interaction, "❌ Withdrawal amount must be at least 1 sand.", use_followup=use_followup, ephemeral=True)
+            await send_response(interaction, "❌ Withdrawal amount must be at least 1 melange.", use_followup=use_followup, ephemeral=True)
             return
 
         # Get current guild treasury balance
@@ -39,13 +39,13 @@ async def guild_withdraw(interaction, command_start, user: discord.Member, amoun
             get_database().get_guild_treasury
         )
 
-        current_sand = treasury_data.get('total_sand', 0)
-        if current_sand < amount:
+        current_melange = treasury_data.get('total_melange', 0)
+        if current_melange < amount:
             await send_response(interaction,
                 f"❌ Insufficient guild treasury funds.\n\n"
-                f"**Available:** {current_sand:,} sand\n"
-                f"**Requested:** {amount:,} sand\n"
-                f"**Shortfall:** {amount - current_sand:,} sand",
+                f"**Available:** {current_melange:,.2f} melange\n"
+                f"**Requested:** {amount:,.2f} melange\n"
+                f"**Shortfall:** {amount - current_melange:,.2f} melange",
                 use_followup=use_followup, ephemeral=True)
             return
 
@@ -65,13 +65,13 @@ async def guild_withdraw(interaction, command_start, user: discord.Member, amoun
 
         # Build response embed
         fields = {
-            "💸 Transaction": f"**Recipient:** {user.display_name} | **Amount:** {amount:,} sand | **Admin:** {interaction.user.display_name}",
-            "🏛️ Treasury": f"**Previous:** {current_sand:,} | **New:** {updated_treasury.get('total_sand', 0):,} | **Available:** {updated_treasury.get('total_sand', 0):,}"
+            "💸 Transaction": f"**Recipient:** {user.display_name} | **Amount:** {amount:,.2f} melange | **Admin:** {interaction.user.display_name}",
+            "🏛️ Treasury": f"**Previous:** {current_melange:,.2f} | **New:** {updated_treasury.get('total_melange', 0):,.2f} | **Available:** {updated_treasury.get('total_melange', 0):,.2f}"
         }
 
         embed = build_status_embed(
             title="✅ Guild Withdrawal Completed",
-            description=f"💰 **{amount:,} sand** transferred from guild treasury to **{user.display_name}**",
+            description=f"💰 **{amount:,.2f} melange** transferred from guild treasury to **{user.display_name}**",
             color=0x00FF00,
             fields=fields,
             timestamp=interaction.created_at
@@ -97,12 +97,12 @@ async def guild_withdraw(interaction, command_start, user: discord.Member, amoun
             withdraw_time=f"{withdraw_time:.3f}s",
             response_time=f"{response_time:.3f}s",
             withdrawal_amount=amount,
-            previous_balance=current_sand,
-            new_balance=updated_treasury.get('total_sand', 0)
+            previous_balance=current_melange,
+            new_balance=updated_treasury.get('total_melange', 0)
         )
 
         # Log the withdrawal for audit
-        logger.info(f"Guild withdrawal: {amount:,} sand from treasury to {user.display_name} ({user.id}) by {interaction.user.display_name} ({interaction.user.id})")
+        logger.info(f"Guild withdrawal: {amount:,.2f} melange from treasury to {user.display_name} ({user.id}) by {interaction.user.display_name} ({interaction.user.id})")
 
     except ValueError as ve:
         # Handle insufficient funds or other validation errors

--- a/commands/guild_withdraw.py
+++ b/commands/guild_withdraw.py
@@ -7,8 +7,8 @@ COMMAND_METADATA = {
     'aliases': [],  # ['gwithdraw']
     'description': "Withdraw melange from guild treasury to give to a user (Admin/Officer only)",
     'params': {
-        'user': "User to give melange to",
-        'amount': "Amount of melange to withdraw from guild treasury"
+        'user': "The user whose ledger to credit melange",
+        'amount': "Amount of melange to credit from guild treasury"
     },
     'permission_level': 'admin_or_officer'
 }

--- a/commands/guild_withdraw.py
+++ b/commands/guild_withdraw.py
@@ -18,7 +18,7 @@ import discord
 from utils.database_utils import timed_database_operation
 from utils.embed_utils import build_status_embed
 from utils.command_utils import log_command_metrics
-from utils.helpers import get_database, send_response
+from utils.helpers import get_database, send_response, format_melange
 from utils.base_command import admin_command
 from utils.logger import logger
 
@@ -43,9 +43,9 @@ async def guild_withdraw(interaction, command_start, user: discord.Member, amoun
         if current_melange < amount:
             await send_response(interaction,
                 f"❌ Insufficient guild treasury funds.\n\n"
-                f"**Available:** {current_melange:,.2f} melange\n"
-                f"**Requested:** {amount:,.2f} melange\n"
-                f"**Shortfall:** {amount - current_melange:,.2f} melange",
+                f"**Available:** {format_melange(current_melange)} melange\n"
+                f"**Requested:** {format_melange(amount)} melange\n"
+                f"**Shortfall:** {format_melange(amount - current_melange)} melange",
                 use_followup=use_followup, ephemeral=True)
             return
 
@@ -65,13 +65,13 @@ async def guild_withdraw(interaction, command_start, user: discord.Member, amoun
 
         # Build response embed
         fields = {
-            "💸 Transaction": f"**Recipient:** {user.display_name} | **Amount:** {amount:,.2f} melange | **Admin:** {interaction.user.display_name}",
-            "🏛️ Treasury": f"**Previous:** {current_melange:,.2f} | **New:** {updated_treasury.get('total_melange', 0):,.2f} | **Available:** {updated_treasury.get('total_melange', 0):,.2f}"
+            "💸 Transaction": f"**Recipient:** {user.display_name} | **Amount:** {format_melange(amount)} melange | **Admin:** {interaction.user.display_name}",
+            "🏛️ Treasury": f"**Previous:** {format_melange(current_melange)} | **New:** {format_melange(updated_treasury.get('total_melange', 0))} | **Available:** {format_melange(updated_treasury.get('total_melange', 0))}"
         }
 
         embed = build_status_embed(
             title="✅ Guild Withdrawal Completed",
-            description=f"💰 **{amount:,.2f} melange** transferred from guild treasury to **{user.display_name}**",
+            description=f"💰 **{format_melange(amount)} melange** transferred from guild treasury to **{user.display_name}**",
             color=0x00FF00,
             fields=fields,
             timestamp=interaction.created_at
@@ -102,7 +102,7 @@ async def guild_withdraw(interaction, command_start, user: discord.Member, amoun
         )
 
         # Log the withdrawal for audit
-        logger.info(f"Guild withdrawal: {amount:,.2f} melange from treasury to {user.display_name} ({user.id}) by {interaction.user.display_name} ({interaction.user.id})")
+        logger.info(f"Guild withdrawal: {format_melange(amount)} melange from treasury to {user.display_name} ({user.id}) by {interaction.user.display_name} ({interaction.user.id})")
 
     except ValueError as ve:
         # Handle insufficient funds or other validation errors

--- a/commands/ledger.py
+++ b/commands/ledger.py
@@ -16,16 +16,9 @@ from utils.database_utils import timed_database_operation, validate_user_exists
 from utils.embed_utils import build_status_embed
 from utils.command_utils import log_command_metrics
 from utils.base_command import command
-from utils.helpers import get_database, send_response
+from utils.helpers import get_database, send_response, format_melange
 
 DEPOSITS_PER_PAGE = 10
-
-def format_melange(amount):
-    """Formats melange amount, removing .00 for whole numbers."""
-    if amount == int(amount):
-        return f"{int(amount):,}"
-    else:
-        return f"{amount:,.2f}"
 
 async def build_ledger_embed(interaction, user, deposits, page, total_pages):
     """Build the embed for the ledger."""
@@ -47,9 +40,15 @@ async def build_ledger_embed(interaction, user, deposits, page, total_pages):
                 deposit_type = "🚀 Expedition"
             elif deposit['type'] == 'group':
                 deposit_type = "👥 Group"
+            elif deposit['type'] == 'Guild':
+                deposit_type = "🏛️ Guild"
             else:
                 deposit_type = "🏜️ Solo"
-            ledger_text += f"**{deposit['sand_amount']:,} sand** {melange_str} {deposit_type} - {date_str}\n"
+
+            if deposit['type'] == 'Guild':
+                ledger_text += f"{melange_str} {deposit_type} - {date_str}\n"
+            else:
+                ledger_text += f"**{deposit['sand_amount']:,} sand** {melange_str} {deposit_type} - {date_str}\n"
 
     total_melange = user.get('total_melange', 0) if user else 0
     paid_melange = user.get('paid_melange', 0) if user else 0

--- a/commands/ledger.py
+++ b/commands/ledger.py
@@ -32,7 +32,7 @@ async def build_ledger_embed(interaction, user, deposits, page, total_pages):
             melange_amount = deposit.get('melange_amount')
 
             if melange_amount is not None:
-                melange_str = f"-> **{format_melange(melange_amount)} melange**"
+                melange_str = f"**{format_melange(melange_amount)} melange**"
             else:
                 melange_str = "(legacy)"
 
@@ -48,7 +48,7 @@ async def build_ledger_embed(interaction, user, deposits, page, total_pages):
             if deposit['type'] == 'Guild':
                 ledger_text += f"{melange_str} {deposit_type} - {date_str}\n"
             else:
-                ledger_text += f"**{deposit['sand_amount']:,} sand** {melange_str} {deposit_type} - {date_str}\n"
+                ledger_text += f"**{deposit['sand_amount']:,} sand** -> {melange_str} {deposit_type} - {date_str}\n"
 
     total_melange = user.get('total_melange', 0) if user else 0
     paid_melange = user.get('paid_melange', 0) if user else 0

--- a/database_orm.py
+++ b/database_orm.py
@@ -880,7 +880,7 @@ class Database:
 
             await self._log_operation("update", "users", start_time, success=True,
                                     count=count, total_paid=total_paid)
-            return count
+            return {'total_paid': total_paid, 'users_paid': count}
 
         except Exception as e:
             await self._log_operation("update", "users", start_time, success=False,

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -172,3 +172,11 @@ def build_admin_officer_role_mentions() -> str:
     except Exception as e:
         logger.warning(f"Failed to build admin/officer role mentions: {e}")
         return ""
+
+
+def format_melange(amount: float) -> str:
+    """Formats melange amount, removing .00 for whole numbers."""
+    if amount == int(amount):
+        return f"{int(amount):,}"
+    else:
+        return f"{amount:,.2f}"


### PR DESCRIPTION
## Feature/guild withdraw melange; Implements the `guild_withdraw` command to allow admins to withdraw melange from the guild treasury and grant it to a user.

The changes include:
- A new `guild_withdraw` method in `database_orm.py` that atomically handles the withdrawal logic.
- Updates the user's total melange in the `users` table.
- Logs the withdrawal in the `guild_transactions` table.
- Creates a corresponding entry in the `deposits` table with type "Guild" and sand set to 0.
- Updates the command in `commands/guild_withdraw.py` to use the new database method and reflect that the currency is melange, not sand.

## Bugfixes:
- addresses a bug in the `/payroll` command that caused an `AttributeError: 'int' object has no attribute 'get'`. The `pay_all_pending_melange` function in `database_orm.py` was returning an integer instead of the dictionary that the `payroll` command expected. This has been fixed by updating the function to return a dictionary containing both the number of users paid and the total amount paid.

## Other
- A new helper function `format_melange` has been added to `utils/helpers.py` and is used by both commands to ensure consistent formatting.

^yeah i know this last one shouldn't be needed, but I found that I made a lil whoopsie in the "deposits" table when I made the "melange_amount" column a float instead of rounding up and casting the melange value calculated on conversion_rate to an int (since the landsraad 37.5 conversion wants to make it a float by default). I don't want to introduce a database migration for that since you would rather stable bot and bugfix commits during the week, but i'll make sure it's addressed at some point in the next cycle so all melange values are consistent int values, sorry