### PR TITLE
feat: Cache Landsraad bonus status in memory

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -62,6 +62,10 @@ async def on_ready():
             db_init_time = time.time() - db_init_start
             logger.bot_event("Database connection verified", db_init_time=f"{db_init_time:.3f}s")
 
+            # Initialize landsraad bonus status cache
+            from utils.helpers import initialize_bonus_status
+            await initialize_bonus_status()
+
         except Exception as error:
             db_init_time = time.time() - db_init_start
             logger.bot_event(f"Database connection failed: {error}", db_init_time=f"{db_init_time:.3f}s")

--- a/commands/landsraad.py
+++ b/commands/landsraad.py
@@ -17,7 +17,7 @@ import time
 from utils.database_utils import timed_database_operation
 from utils.embed_utils import build_status_embed
 from utils.command_utils import log_command_metrics
-from utils.helpers import get_database, get_sand_per_melange_with_bonus, send_response
+from utils.helpers import get_database, get_sand_per_melange_with_bonus, send_response, update_landsraad_bonus_status
 from utils.base_command import command
 from utils.logger import logger
 
@@ -97,6 +97,8 @@ async def landsraad(interaction, command_start, action: str, confirm: bool = Fal
                 get_database().set_landsraad_bonus_status,
                 new_status
             )
+            # Update the cache
+            update_landsraad_bonus_status(new_status)
 
             # Get updated conversion rate
             conversion_rate = await get_sand_per_melange_with_bonus()

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -5,7 +5,7 @@ Helper functions used across multiple commands.
 import os
 from typing import List
 from database_orm import Database
-
+from utils.logger import logger
 # Initialize database (lazy initialization)
 database = None
 
@@ -30,7 +30,6 @@ _landsraad_bonus_active = False # Default value
 async def initialize_bonus_status():
     """Called once when the bot starts up."""
     global _landsraad_bonus_active
-    from utils.logger import logger
     try:
         db = get_database()
         status = await db.get_landsraad_bonus_status()
@@ -48,7 +47,6 @@ def update_landsraad_bonus_status(new_status: bool):
     """Updates the in-memory cache."""
     global _landsraad_bonus_active
     _landsraad_bonus_active = new_status
-    from utils.logger import logger
     logger.info(f"Landsraad bonus status updated in cache: {new_status}")
 
 


### PR DESCRIPTION
- Loads the Landsraad bonus status from the database on startup and stores it in a global variable.
- Modifies `get_sand_per_melange_with_bonus` to read from the in-memory cache instead of the database.
- Updates the `landsraad` command to update both the database and the in-memory cache when the bonus status is changed.
- Adds robust error handling for the cache initialization.
- Updates tests to reflect the new caching mechanism.

modeled after the way you recommended in https://github.com/jaqknife777/spice-tracker-bot/issues/47#issuecomment-3303563613 @ShonM - also retains current frontend bot operations when merged, so should be transparent to end users.