### PR TITLE
Fix/melange float to int

### DIFF
--- a/alembic/versions/13a333854712_change_melange_amount_to_integer_in_.py
+++ b/alembic/versions/13a333854712_change_melange_amount_to_integer_in_.py
@@ -1,0 +1,51 @@
+"""Change melange_amount to Integer in deposits table
+
+Revision ID: 13a333854712
+Revises: a1db1fd306c3
+Create Date: 2025-09-17 02:59:24.531099
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '13a333854712'
+down_revision: Union[str, Sequence[str], None] = 'a1db1fd306c3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        op.alter_column('deposits', 'melange_amount',
+                   existing_type=sa.FLOAT(),
+                   type_=sa.Integer(),
+                   existing_nullable=True,
+                   postgresql_using='melange_amount::integer')
+    else:
+        with op.batch_alter_table('deposits', schema=None) as batch_op:
+            batch_op.alter_column('melange_amount',
+                   existing_type=sa.FLOAT(),
+                   type_=sa.Integer(),
+                   existing_nullable=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        op.alter_column('deposits', 'melange_amount',
+                   existing_type=sa.Integer(),
+                   type_=sa.FLOAT(),
+                   existing_nullable=True)
+    else:
+        with op.batch_alter_table('deposits', schema=None) as batch_op:
+            batch_op.alter_column('melange_amount',
+                   existing_type=sa.Integer(),
+                   type_=sa.FLOAT(),
+                   existing_nullable=True)

--- a/database_orm.py
+++ b/database_orm.py
@@ -33,8 +33,8 @@ class User(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
     username: Mapped[str] = mapped_column(String(100), nullable=False)
-    total_melange: Mapped[float] = mapped_column(Float, default=0.0)
-    paid_melange: Mapped[float] = mapped_column(Float, default=0.0)
+    total_melange: Mapped[int] = mapped_column(Integer, default=0)
+    paid_melange: Mapped[int] = mapped_column(Integer, default=0)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.utcnow())
     last_updated: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.utcnow(), onupdate=lambda: datetime.utcnow())
 
@@ -60,7 +60,7 @@ class Deposit(Base):
     sand_amount: Mapped[int] = mapped_column(Integer, nullable=False)
     type: Mapped[str] = mapped_column(String(20), default="solo")
     expedition_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("expeditions.id"))
-    melange_amount: Mapped[Optional[float]] = mapped_column(Float)
+    melange_amount: Mapped[Optional[int]] = mapped_column(Integer)
     conversion_rate: Mapped[Optional[float]] = mapped_column(Float)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.utcnow())
 
@@ -123,7 +123,7 @@ class GuildTreasury(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     total_sand: Mapped[int] = mapped_column(Integer, default=0)
-    total_melange: Mapped[float] = mapped_column(Float, default=0.0)
+    total_melange: Mapped[int] = mapped_column(Integer, default=0)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.utcnow())
     last_updated: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.utcnow(), onupdate=lambda: datetime.utcnow())
 
@@ -381,7 +381,7 @@ class Database:
             await self._log_operation("upsert", "users", start_time, success=False, user_id=user_id, username=username, error=str(e))
             raise e
 
-    async def add_deposit(self, user_id: str, username: str, sand_amount: int, deposit_type: str = 'solo', expedition_id: Optional[int] = None, melange_amount: Optional[float] = None, conversion_rate: Optional[float] = None):
+    async def add_deposit(self, user_id: str, username: str, sand_amount: int, deposit_type: str = 'solo', expedition_id: Optional[int] = None, melange_amount: Optional[int] = None, conversion_rate: Optional[float] = None):
         """Add a new sand deposit for a user"""
         start_time = time.time()
         try:
@@ -498,7 +498,7 @@ class Database:
             await self._log_operation("select", "guild_treasury", start_time, success=False, error=str(e))
             raise e
 
-    async def update_guild_treasury(self, sand_amount: int, melange_amount: float = 0):
+    async def update_guild_treasury(self, sand_amount: int, melange_amount: int = 0):
         """Add sand and melange to guild treasury"""
         start_time = time.time()
         try:
@@ -531,7 +531,7 @@ class Database:
     # Add other methods as needed...
     # For brevity, I'll add a few more key methods
 
-    async def update_user_melange(self, user_id: str, melange_amount: float):
+    async def update_user_melange(self, user_id: str, melange_amount: int):
         """Update user melange amount"""
         start_time = time.time()
         try:
@@ -643,7 +643,7 @@ class Database:
                                         user_id=user_id, error=str(e))
                 raise e
 
-    async def get_user_pending_melange(self, user_id: str) -> Dict[str, float]:
+    async def get_user_pending_melange(self, user_id: str) -> Dict[str, int]:
         """Get pending melange amount for a user"""
         start_time = time.time()
         async with self._get_session() as session:
@@ -656,7 +656,7 @@ class Database:
                         'pending_melange': user['total_melange'] - user['paid_melange']
                     }
                 else:
-                    result = {'total_melange': 0.0, 'paid_melange': 0.0, 'pending_melange': 0.0}
+                    result = {'total_melange': 0, 'paid_melange': 0, 'pending_melange': 0}
 
                 await self._log_operation("select", "users", start_time, success=True,
                                         user_id=user_id, pending_melange=result['pending_melange'])
@@ -809,7 +809,7 @@ class Database:
         """Get expedition deposits for a specific user"""
         raise NotImplementedError("Method needs to be implemented")
 
-    async def pay_user_melange(self, user_id: str, username: str, melange_amount: float,
+    async def pay_user_melange(self, user_id: str, username: str, melange_amount: int,
                              admin_user_id: Optional[str] = None, admin_username: Optional[str] = None):
         """Pay melange to a user and record the payment"""
         start_time = time.time()

--- a/tests/test_orm_database.py
+++ b/tests/test_orm_database.py
@@ -28,8 +28,8 @@ class TestORMDatabase:
         assert user is not None
         assert user['user_id'] == user_id
         assert user['username'] == username
-        assert user['total_melange'] == 0.0
-        assert user['paid_melange'] == 0.0
+        assert user['total_melange'] == 0
+        assert user['paid_melange'] == 0
 
     @pytest.mark.asyncio
     async def test_deposit_operations(self, test_database):
@@ -55,7 +55,7 @@ class TestORMDatabase:
         """Test melange operations."""
         user_id = "123456789"
         username = "TestUser"
-        melange_amount = 10.5
+        melange_amount = 10
 
         # Ensure user exists
         await test_database.upsert_user(user_id, username)
@@ -70,7 +70,7 @@ class TestORMDatabase:
         # Test get_user_pending_melange
         pending = await test_database.get_user_pending_melange(user_id)
         assert pending['total_melange'] == melange_amount
-        assert pending['paid_melange'] == 0.0
+        assert pending['paid_melange'] == 0
         assert pending['pending_melange'] == melange_amount
 
     @pytest.mark.asyncio
@@ -108,14 +108,14 @@ class TestORMDatabase:
     async def test_guild_treasury_operations(self, test_database):
         """Test guild treasury operations."""
         sand_amount = 10000
-        melange_amount = 200.5
+        melange_amount = 200
 
         # Test get_guild_treasury (should create initial record)
         treasury = await test_database.get_guild_treasury()
         assert treasury['total_sand'] == 0
-        assert treasury['total_melange'] == 0.0
+        assert treasury['total_melange'] == 0
 
-        # Test update_guild_treasury
+        # Test update_guild_treasry
         await test_database.update_guild_treasury(sand_amount, melange_amount)
 
         # Verify update
@@ -128,9 +128,9 @@ class TestORMDatabase:
         """Test leaderboard operations."""
         # Create multiple users with different melange amounts
         users_data = [
-            ("user1", "UserOne", 100.0),
-            ("user2", "UserTwo", 50.0),
-            ("user3", "UserThree", 75.0)
+            ("user1", "UserOne", 100),
+            ("user2", "UserTwo", 50),
+            ("user3", "UserThree", 75)
         ]
 
         for user_id, username, melange in users_data:
@@ -142,9 +142,9 @@ class TestORMDatabase:
         assert len(leaderboard) == 3
 
         # Should be sorted by melange amount descending
-        assert leaderboard[0]['total_melange'] == 100.0
-        assert leaderboard[1]['total_melange'] == 75.0
-        assert leaderboard[2]['total_melange'] == 50.0
+        assert leaderboard[0]['total_melange'] == 100
+        assert leaderboard[1]['total_melange'] == 75
+        assert leaderboard[2]['total_melange'] == 50
 
     @pytest.mark.asyncio
     async def test_database_cleanup(self, test_database):
@@ -180,12 +180,12 @@ class TestORMDatabase:
 
         # Ensure user exists
         await test_database.upsert_user(user_id, username)
-        await test_database.update_user_melange(user_id, 25.0)
+        await test_database.update_user_melange(user_id, 25)
 
         # Test get_user_stats
         stats = await test_database.get_user_stats(user_id)
         assert stats is not None
-        assert stats['total_melange'] == 25.0
+        assert stats['total_melange'] == 25
         assert 'timing' in stats
 
     @pytest.mark.asyncio
@@ -215,7 +215,7 @@ class TestPaginatedDepositOperations:
         username = "PaginationUser"
         await test_database.upsert_user(user_id, username)
         for i in range(25):
-            await test_database.add_deposit(user_id, username, 100 + i, melange_amount=2.0, conversion_rate=50.0)
+            await test_database.add_deposit(user_id, username, 100 + i, melange_amount=2, conversion_rate=50.0)
         return user_id
 
     @pytest.mark.asyncio


### PR DESCRIPTION
This change addresses (https://github.com/jaqknife777/spice-tracker-bot/issues/45) an issue where columns storing melange amounts were incorrectly defined as Float instead of Integer.

- The `melange_amount` column in the `deposits` table has been changed from `FLOAT` to `INTEGER`. A database migration is included to apply this change and truncate existing data.
- The `total_melange` and `paid_melange` columns in the `users` table have been changed from `Float` to `Integer` in the ORM to match the production schema.
- The `total_melange` column in the `guild_treasury` table has been changed from `Float` to `Integer` in the ORM to match the production schema.
- Type hints in various database methods have been updated to reflect these changes.
- The melange calculation logic in `utils/helpers.py` was reviewed and confirmed to correctly round down, so no changes were needed there.

@ShonM this PR was tested on top of https://github.com/jaqknife777/spice-tracker-bot/pull/52 in my test environment but should be able to be merged independently without issue, as they don't conflict with each other.